### PR TITLE
ci: establish Issue → PR → CI → merge delivery loop

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!--
+Delivery loop: Issue → PR into main → CI green → merge → Issue auto-closes.
+  • Base branch is always `main`.
+  • Reference the primary Issue with `Fixes #N` or `Closes #N` so it closes on merge only.
+  • CI (`ci / test`) must be green before merging; never merge red.
+  • One primary Issue per PR; no secrets or machine-local junk in commits.
+See AGENTS.md / CONTRIBUTING.md for the full loop.
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? Link any relevant context. -->
+
+## Fixes
+
+Fixes #<!-- issue number -->
+
+## Test plan
+
+<!-- How did you verify this? Add steps so a reviewer can reproduce. -->
+-
+-
+
+## Notes for review
+
+<!-- Anything reviewers should pay attention to, trade-offs, or follow-ups. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,8 @@ jobs:
           pip install pytest
 
       - name: Run tests
+        env:
+          # The test suite imports the `server` package from the repo root,
+          # so make the repo root importable when pytest runs from /tests.
+          PYTHONPATH: .
         run: pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+# Continuous Integration — the merge gate for pull requests into `main`.
+#
+# Runs the pytest suite on every push to main and on every PR. A green run
+# is required before merging. This workflow MUST NOT close issues (issues
+# close via `Fixes #N` / `Closes #N` in the PR body, on merge only).
+#
+# Required check name for branch protection: `ci / test (Python <version>)`
+# (pick one version, e.g. 3.11, as the required check; the rest are advisory).
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r server/requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+Guidance for coding agents (and humans using them) working in this repository.
+
+## Project overview
+
+WebToApp turns any website into installable apps (iOS / Android / Windows / macOS / Linux).
+- Backend: Python 3.10+ · FastAPI · Uvicorn (`server/`).
+- Frontend: plain HTML / CSS / JS served statically (`index.html`, `css/`, `js/`).
+- APK toolchain: Android SDK (aapt2 / d8 / apksigner / zipalign) + apktool + JDK.
+- Tests: `pytest tests/`. Run them before every PR.
+
+Runtime/user data lives under `generated/`; signing material under `certs/`.
+Both are git-ignored — **never commit them**.
+
+## Delivery loop
+
+Every intentional change follows this loop. Hard rules:
+
+1. **Base branch is always `main`.** Feature PRs target `main` only.
+2. **Issue first.** Reuse an open Issue when one tracks the work; otherwise create one. Title short and actionable; body = problem/goal + scope + acceptance.
+3. **Branch from up-to-date `main`.** Use a descriptive name (e.g. `fix/...`, `feat/...`).
+4. **Commit only intended files.** No secrets, no `generated/`, no `certs/*.keystore|*.pem`, no IDE/OS junk. Clear *why* in the message.
+5. **Open a PR into `main`** with `Fixes #N` or `Closes #N` in the body, plus a Summary and a Test plan (the PR template reminds you). The Issue closes **on merge only** — never when the PR is opened or while CI is red.
+6. **CI is the merge gate.** The `ci / test` workflow runs `pytest tests/` on Python 3.10 / 3.11 / 3.12. Do not merge red checks. CI never auto-closes Issues.
+7. **One primary Issue per PR.** Extra Issues: link in the body without extra closing keywords.
+8. **If you cannot merge** (no permission): open the PR, comment on the Issue with the PR URL and CI status, leave the Issue open, and hand off to a maintainer.
+
+Canonical flow:
+
+```
+Issue open → PR open (Fixes #N, base=main) → CI
+  ├─ red  → fix & push (Issue stays open)
+  └─ green → merge to main → Issue auto-closes
+```
+
+### Frontend cache-busting
+
+When you change `css/` or `js/`, bump the `?v=` query string in `index.html`
+so browsers fetch the new files instead of cached ones.
+
+### Deploying
+
+This repo is deployed as bare files (not a git checkout) on the server. After
+merging, sync the changed files to the deploy directory and restart the
+service. If you changed the APK Java template (`server/engine/apk_builder.py`),
+also delete the cached `server/engine/_android_template/android-template.apk`
+and `template.revision` before restarting, or the Java change won't take effect.
+
+## Overrides
+
+User overrides win for that turn only (e.g. skip Issue, direct push to `main`,
+ignore red CI) — state the override in the PR/Issue comment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to WebToApp
+
+Thanks for helping improve WebToApp! This short guide covers how changes land in the project.
+
+## The delivery loop
+
+Every intentional change — feature, fix, or docs — follows the same loop:
+
+```
+Issue → PR into main → CI green → merge → Issue auto-closes
+```
+
+1. **Start from an Issue.** If none exists for your change, [open one](https://github.com/shiaho777/WebToApp/issues/new) describing the problem and the intended scope.
+2. **Branch from `main`.** Use a descriptive name (`fix/...`, `feat/...`, `docs/...`).
+3. **Make your changes.** Keep commits focused. Don't commit secrets, `generated/`, `certs/*.keystore` / `*.pem`, or IDE/OS files — they're git-ignored for a reason.
+4. **Run the tests locally:**
+   ```bash
+   pip install -r server/requirements.txt
+   pip install pytest
+   pytest tests/
+   ```
+5. **Open a pull request into `main`.** Fill in the PR template:
+   - **Summary** — what and why.
+   - **Fixes #N** (or `Closes #N`) — so the Issue closes automatically when the PR merges.
+   - **Test plan** — how you verified the change.
+6. **Wait for CI.** The `ci / test` workflow runs the test suite on Python 3.10 / 3.11 / 3.12. It must be green before merging.
+7. **Merge.** Once green, a maintainer merges the PR and the Issue closes on its own.
+
+## Rules
+
+- **Base branch is `main`.** Feature PRs target `main` only.
+- **CI is the merge gate.** Don't merge red checks. CI never auto-closes Issues — Issues close via `Fixes #N` / `Closes #N` on merge.
+- **One primary Issue per PR.** Reference other Issues by link, not by closing keyword.
+- **Frontend changes:** bump the `?v=` cache-busting stamp in `index.html` when you change `css/` or `js/`.
+
+## Reporting bugs
+
+Open an Issue with:
+- What you expected, and what happened instead.
+- The URL you tried (for WebToApp itself, or the site you wrapped).
+- Steps to reproduce, and your platform / browser.
+
+## Code of conduct
+
+Be kind and constructive. We're all here to make a useful tool.

--- a/CONTRIBUTING.zh.md
+++ b/CONTRIBUTING.zh.md
@@ -1,0 +1,47 @@
+# 贡献指南 (简体中文)
+
+感谢你参与改进 WebToApp!本指南说明改动如何合入本项目。
+
+**English** · 简体中文
+
+## 交付流程
+
+每一次有意识的改动 —— 新功能、修复或文档 —— 都遵循同一条流程:
+
+```
+Issue → 向 main 提 PR → CI 通过 → 合并 → Issue 自动关闭
+```
+
+1. **从 Issue 开始。** 如果还没有对应 Issue,[新建一个](https://github.com/shiaho777/WebToApp/issues/new),描述问题和改动范围。
+2. **从 `main` 切分支。** 用清晰的命名(`fix/...`、`feat/...`、`docs/...`)。
+3. **实施改动。** 保持提交聚焦。不要提交密钥、`generated/`、`certs/*.keystore` / `*.pem` 或 IDE/系统垃圾文件 —— 它们已被 git 忽略。
+4. **本地跑测试:**
+   ```bash
+   pip install -r server/requirements.txt
+   pip install pytest
+   pytest tests/
+   ```
+5. **向 `main` 提 Pull Request。** 按模板填写:
+   - **Summary** —— 改了什么、为什么。
+   - **Fixes #N**(或 `Closes #N`) —— 让 Issue 在 PR 合并时自动关闭。
+   - **Test plan** —— 你是怎么验证的。
+6. **等 CI。** `ci / test` 会在 Python 3.10 / 3.11 / 3.12 上跑测试套件,必须全绿才能合并。
+7. **合并。** CI 绿之后,维护者合并 PR,Issue 会自动关闭。
+
+## 规则
+
+- **基线分支是 `main`。** 功能 PR 只能合进 `main`。
+- **CI 是合并门槛。** 不要合并红色检查。CI 绝不自动关闭 Issue —— Issue 通过 `Fixes #N` / `Closes #N` 在合并时关闭。
+- **一个 PR 对应一个主 Issue。** 其他 Issue 用链接引用,不要带额外的关闭关键词。
+- **前端改动:** 改 `css/` 或 `js/` 时,记得 bump `index.html` 里的 `?v=` 缓存戳。
+
+## 报告 Bug
+
+开 Issue 时请包含:
+- 期望的行为 vs 实际发生的情况。
+- 你测试的 URL(WebToApp 本身的网址,或你封装的目标网站)。
+- 复现步骤,以及你的平台 / 浏览器。
+
+## 行为准则
+
+友善、建设性。我们都是为了做出一个好用的工具。

--- a/tests/test_coverage_analyzer.py
+++ b/tests/test_coverage_analyzer.py
@@ -1,0 +1,405 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+import server.engine.analyzer as analyzer_module
+from server.engine.analyzer import SiteAnalyzer
+
+
+class DummyCache:
+    def __init__(self, initial=None):
+        self.data = dict(initial or {})
+        self.set_calls = []
+
+    def get(self, key):
+        return self.data.get(key)
+
+    def set(self, key, value):
+        self.data[key] = value
+        self.set_calls.append((key, value))
+
+
+class FakeAsyncResponse:
+    def __init__(self, status_code=200, headers=None, encoding="utf-8"):
+        self.status_code = status_code
+        self.headers = dict(headers or {})
+        self.encoding = encoding
+        self.raised = False
+
+    def raise_for_status(self):
+        self.raised = True
+
+
+class FakeAsyncStream:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class FakeAsyncClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def stream(self, method, url):
+        self.requests.append((method, url))
+        return FakeAsyncStream(self.responses.pop(0))
+
+
+def test_analyze_cache_hit_returns_copy_and_duration(monkeypatch):
+    cache = DummyCache({"analyze:https://cached.example": {"title": "Cached", "cacheHit": False}})
+    monkeypatch.setattr(analyzer_module, "analysis_cache", cache)
+    analyzer = SiteAnalyzer()
+    analyzer._fetch_page = AsyncMock(side_effect=AssertionError("must not fetch"))
+
+    result = asyncio.run(analyzer.analyze("https://cached.example"))
+    assert result["title"] == "Cached"
+    assert result["cacheHit"] is True
+    assert isinstance(result["durationMs"], int)
+    assert cache.data["analyze:https://cached.example"]["cacheHit"] is False
+
+
+def test_analyze_miss_normalizes_url_and_populates_alias_caches(monkeypatch):
+    analysis = DummyCache()
+    html = DummyCache()
+    monkeypatch.setattr(analyzer_module, "analysis_cache", analysis)
+    monkeypatch.setattr(analyzer_module, "html_cache", html)
+    analyzer = SiteAnalyzer()
+    analyzer._fetch_page = AsyncMock(
+        return_value=("https://final.example/page", "<title>Final</title>", 20, b"raw html", "")
+    )
+    analyzer._analyze_html = AsyncMock(return_value={"title": "Final"})
+
+    result = asyncio.run(analyzer.analyze("start.example"))
+    analyzer._fetch_page.assert_awaited_once_with("https://start.example")
+    analyzer._analyze_html.assert_awaited_once_with("https://final.example/page", "<title>Final</title>", 20)
+    assert result["cacheHit"] is False
+    assert html.data["bytes:https://final.example/page"] == b"raw html"
+    assert html.data["bytes:https://start.example"] == b"raw html"
+    assert analysis.data["analyze:https://start.example"]["title"] == "Final"
+    assert analysis.data["analyze:https://final.example/page"]["title"] == "Final"
+
+
+def test_analyze_miss_same_url_and_no_raw_skips_aliases(monkeypatch):
+    analysis = DummyCache()
+    html = DummyCache()
+    monkeypatch.setattr(analyzer_module, "analysis_cache", analysis)
+    monkeypatch.setattr(analyzer_module, "html_cache", html)
+    analyzer = SiteAnalyzer()
+    analyzer._fetch_page = AsyncMock(return_value=("http://same.example", "html", 4, None, ""))
+    analyzer._analyze_html = AsyncMock(return_value={"ok": True})
+
+    result = asyncio.run(analyzer.analyze("http://same.example"))
+    assert result["ok"] is True
+    assert html.set_calls == []
+    assert [key for key, _ in analysis.set_calls] == ["analyze:http://same.example"]
+
+
+def test_fetch_page_uses_cached_bytes(monkeypatch):
+    cache = DummyCache({"bytes:https://cached.example": "café".encode("utf-8")})
+    monkeypatch.setattr(analyzer_module, "html_cache", cache)
+    monkeypatch.setattr(analyzer_module, "avalidate_public_http_url", AsyncMock(return_value="https://cached.example"))
+    analyzer = SiteAnalyzer()
+    analyzer.client = FakeAsyncClient([])
+
+    final_url, html, length, raw, auth_provider = asyncio.run(analyzer._fetch_page("https://cached.example"))
+    assert final_url == "https://cached.example"
+    assert html == "café"
+    assert length == len(raw)
+    assert auth_provider == ""
+    assert analyzer.client.requests == []
+
+
+@pytest.mark.parametrize("encoding", ["latin-1", None])
+def test_fetch_page_reads_network_response_and_encoding(monkeypatch, encoding):
+    cache = DummyCache()
+    response = FakeAsyncResponse(200, encoding=encoding)
+    monkeypatch.setattr(analyzer_module, "html_cache", cache)
+    monkeypatch.setattr(analyzer_module, "avalidate_public_http_url", AsyncMock(return_value="https://page.example"))
+    monkeypatch.setattr(analyzer_module, "aread_limited_response", AsyncMock(return_value=b"caf\xe9"))
+    monkeypatch.setattr(analyzer_module.config, "outbound_redirect_limit", lambda: 2)
+    monkeypatch.setattr(analyzer_module.config, "outbound_response_max_bytes", lambda: 123)
+    analyzer = SiteAnalyzer()
+    analyzer.client = FakeAsyncClient([response])
+
+    final_url, html, length, raw, auth_provider = asyncio.run(analyzer._fetch_page("https://page.example"))
+    assert final_url == "https://page.example"
+    assert raw == b"caf\xe9"
+    assert length == 4
+    assert html == ("café" if encoding else "caf")
+    assert response.raised is True
+    analyzer_module.aread_limited_response.assert_awaited_once_with(response, 123)
+
+
+def test_fetch_page_follows_redirect(monkeypatch):
+    first = FakeAsyncResponse(302, {"location": "/final"})
+    second = FakeAsyncResponse(200)
+    monkeypatch.setattr(analyzer_module, "html_cache", DummyCache())
+    monkeypatch.setattr(analyzer_module, "avalidate_public_http_url", AsyncMock(return_value="https://start.example"))
+    monkeypatch.setattr(analyzer_module, "aread_limited_response", AsyncMock(return_value=b"ok"))
+    monkeypatch.setattr(analyzer_module.config, "outbound_redirect_limit", lambda: 1)
+    monkeypatch.setattr(analyzer_module.config, "outbound_response_max_bytes", lambda: 100)
+    monkeypatch.setattr(
+        analyzer_module.asyncio,
+        "to_thread",
+        AsyncMock(return_value="https://start.example/final"),
+    )
+    analyzer = SiteAnalyzer()
+    analyzer.client = FakeAsyncClient([first, second])
+
+    result = asyncio.run(analyzer._fetch_page("https://start.example"))
+    assert result == ("https://start.example/final", "ok", 2, b"ok", "")
+    analyzer_module.asyncio.to_thread.assert_awaited_once_with(
+        analyzer_module.redirect_target, "https://start.example", "/final"
+    )
+
+
+@pytest.mark.parametrize(
+    "location,headers,expected",
+    [
+        # Cloudflare Access: redirect to the access login portal.
+        (
+            "https://acme.cloudflareaccess.com/cdn-cgi/access/login/abc",
+            {},
+            "cloudflare_access",
+        ),
+        # Authelia: redirect to the portal with the rd= (redirect) marker.
+        (
+            "https://auth.example.com/auth/?rd=https%3A%2F%2Fstart.example",
+            {},
+            "authelia",
+        ),
+        # Authelia: session cookie set directly on a 200.
+        (
+            "",
+            {"set-cookie": "authelia_session=xyz; Path=/; HttpOnly"},
+            "authelia",
+        ),
+    ],
+)
+def test_fetch_page_stops_at_auth_wall(monkeypatch, location, headers, expected):
+    first = FakeAsyncResponse(302, {"location": location, **headers} if location else headers)
+    monkeypatch.setattr(analyzer_module, "html_cache", DummyCache())
+    monkeypatch.setattr(analyzer_module, "avalidate_public_http_url", AsyncMock(return_value="https://start.example"))
+    monkeypatch.setattr(analyzer_module.config, "outbound_redirect_limit", lambda: 5)
+    analyzer = SiteAnalyzer()
+    analyzer.client = FakeAsyncClient([first])
+
+    result = asyncio.run(analyzer._fetch_page("https://start.example"))
+    # Stops immediately at the auth redirect; no real page fetched.
+    assert result == ("https://start.example", "", 0, b"", expected)
+
+
+def test_fetch_page_raises_after_redirect_limit(monkeypatch):
+    response = FakeAsyncResponse(301, {"location": "https://elsewhere.example"})
+    monkeypatch.setattr(analyzer_module, "html_cache", DummyCache())
+    monkeypatch.setattr(analyzer_module, "avalidate_public_http_url", AsyncMock(return_value="https://start.example"))
+    monkeypatch.setattr(analyzer_module.config, "outbound_redirect_limit", lambda: 0)
+    monkeypatch.setattr(analyzer_module.asyncio, "to_thread", AsyncMock(return_value="https://elsewhere.example"))
+    analyzer = SiteAnalyzer()
+    analyzer.client = FakeAsyncClient([response])
+
+    with pytest.raises(httpx.TooManyRedirects, match="Exceeded redirect limit"):
+        asyncio.run(analyzer._fetch_page("https://start.example"))
+
+
+def test_analyze_html_extracts_all_metadata_and_mb_size(monkeypatch):
+    html = """
+    <html><head>
+      <title> Example Portal | News </title>
+      <meta name="description" content="A description">
+      <meta property="og:site_name" content="Example Suite">
+      <meta name="theme-color" content="#010203">
+      <link rel="shortcut icon" href="/icon.png">
+      <script src="https://doubleclick.net/ad.js"></script>
+      <script src="https://cdn.example/analytics.js"></script>
+      <script>inline code</script>
+      <style>body { color: red; }</style>
+    </head><body class="cookie-banner newsletter-modal gdpr"></body></html>
+    """
+    analyzer = SiteAnalyzer()
+    monkeypatch.setattr(analyzer, "_favicon_data_url", lambda url: "data:image/png;base64,WA==")
+    result = asyncio.run(analyzer._analyze_html("https://www.example.com/path", html, 2 * 1024 * 1024))
+
+    assert result["title"] == "Example Portal | News"
+    assert result["suggestedName"] == "Example Suite"
+    assert result["suggestedNameSource"] == "site_name"
+    assert result["siteName"] == "Example Suite"
+    assert result["host"] == "www.example.com"
+    assert result["favicon"] == "https://www.example.com/icon.png"
+    assert result["faviconDataUrl"].startswith("data:image/png")
+    assert result["themeColor"] == "#010203"
+    assert result["description"] == "A description"
+    assert result["ads"] == 1
+    assert result["trackers"] == 2
+    assert result["popups"] == 3
+    assert result["totalScripts"] == 2
+    assert result["originalSize"] == "2.0 MB"
+
+
+def test_analyze_html_uses_host_and_default_metadata(monkeypatch):
+    analyzer = SiteAnalyzer()
+    monkeypatch.setattr(analyzer, "_favicon_data_url", lambda url: "")
+    result = asyncio.run(analyzer._analyze_html("https://m.sample.example", "<html></html>", 512))
+
+    assert result["title"] == "m.sample.example"
+    assert result["siteName"] == ""
+    assert result["themeColor"] == "#7c3aed"
+    assert result["description"] == ""
+    assert result["favicon"] == "https://www.google.com/s2/favicons?domain=m.sample.example&sz=64"
+    assert result["originalSize"] == "0 KB"
+
+
+def test_estimate_distilled_metrics_small_and_large_branches():
+    analyzer = SiteAnalyzer()
+    tiny_few = analyzer._estimate_distilled_metrics(
+        original_kb=0,
+        total_scripts=-1,
+        ad_count=-1,
+        tracker_count=-1,
+        popup_count=-1,
+        inline_js_kb=-1,
+        inline_css_kb=-1,
+        total_bloat_kb=-1,
+    )
+    tiny_many = analyzer._estimate_distilled_metrics(
+        original_kb=10,
+        total_scripts=5,
+        ad_count=0,
+        tracker_count=0,
+        popup_count=0,
+        inline_js_kb=0,
+        inline_css_kb=0,
+        total_bloat_kb=0,
+    )
+    low_savings = analyzer._estimate_distilled_metrics(
+        original_kb=100,
+        total_scripts=0,
+        ad_count=0,
+        tracker_count=0,
+        popup_count=0,
+        inline_js_kb=0,
+        inline_css_kb=0,
+        total_bloat_kb=0,
+    )
+    high_savings = analyzer._estimate_distilled_metrics(
+        original_kb=100,
+        total_scripts=100,
+        ad_count=100,
+        tracker_count=100,
+        popup_count=100,
+        inline_js_kb=100,
+        inline_css_kb=100,
+        total_bloat_kb=100,
+    )
+    floor_twelve = analyzer._estimate_distilled_metrics(
+        original_kb=24,
+        total_scripts=100,
+        ad_count=100,
+        tracker_count=100,
+        popup_count=100,
+        inline_js_kb=100,
+        inline_css_kb=100,
+        total_bloat_kb=100,
+    )
+    assert tiny_few == (0.5, 1.1)
+    assert tiny_many[0] == pytest.approx(6.2)
+    assert low_savings[0] == pytest.approx(92.0)
+    assert high_savings[0] == pytest.approx(18.0)
+    assert floor_twelve[0] == pytest.approx(12.0)
+
+
+@pytest.mark.parametrize(
+    ("metas", "expected"),
+    [
+        ([{"property": "og:site_name", "content": "Open Graph"}], ("Open Graph", "site_name")),
+        ([{"name": "application-name", "content": "Application"}], ("Application", "application_name")),
+        ([{"name": "apple-mobile-web-app-title", "content": "Apple"}], ("Apple", "apple_mobile_web_app_title")),
+        ([], ("", "")),
+    ],
+)
+def test_extract_site_name_sources(metas, expected):
+    analyzer = SiteAnalyzer()
+    doc = analyzer_module.parse_html_metadata("")
+    doc.metas = metas
+    assert analyzer._extract_site_name(doc) == expected
+
+
+def test_suggest_app_name_all_strategies():
+    analyzer = SiteAnalyzer()
+    assert analyzer._suggest_app_name("Title", "example.com", " Site Name ", "custom") == ("Site Name", "custom")
+    assert analyzer._suggest_app_name("Title", "example.com", " Site Name ", "") == ("Site Name", "site_name")
+    assert analyzer._suggest_app_name("", "www.example.com") == ("example", "host_fallback")
+    assert analyzer._suggest_app_name("", "") == ("WebToApp", "host_fallback")
+    assert analyzer._suggest_app_name("News | Example | Other", "example.com") == ("Example", "title_host_match")
+    assert analyzer._suggest_app_name("First | Second", "unrelated.com") == ("First", "title_first_part")
+    assert analyzer._suggest_app_name("Single", "unrelated.com") == ("Single", "title_full")
+    long = "X" * 50
+    assert analyzer._suggest_app_name(long, "unrelated.com") == ("X" * 40 + "...", "title_full")
+
+
+def test_text_title_host_and_trim_helpers_cover_edge_cases():
+    analyzer = SiteAnalyzer()
+    assert analyzer._normalize_text("  A\n -  B | C: ") == "A - B | C"
+    assert analyzer._split_title_parts("A | Alpha | alpha | B | Beta") == ["Alpha", "Beta"]
+    assert analyzer._split_title_parts("") == []
+    assert analyzer._split_title_parts("A") == ["A"]
+    assert analyzer._host_label("www.m.mobile.Example.com") == "example"
+    assert analyzer._host_label("") == ""
+    assert analyzer._part_matches_host("anything", "") is False
+    assert analyzer._part_matches_host("Example App", "example") is True
+    assert analyzer._part_matches_host("exam", "example") is True
+    assert analyzer._part_matches_host("other", "example") is False
+    assert analyzer._trim_app_name(" short ") == "short"
+    assert analyzer._trim_app_name("word " * 20).endswith("...")
+
+
+def test_extract_favicon_skips_empty_href_and_falls_back():
+    analyzer = SiteAnalyzer()
+    doc = analyzer_module.parse_html_metadata(
+        '<link rel="icon"><link rel="apple-touch-icon" href="icons/touch.png">'
+    )
+    assert analyzer._extract_favicon(doc, "https://example.com/path/page") == "https://example.com/path/icons/touch.png"
+    empty = analyzer_module.parse_html_metadata('<link rel="stylesheet" href="style.css">')
+    assert analyzer._extract_favicon(empty, "https://example.com") == "https://www.google.com/s2/favicons?domain=example.com&sz=64"
+
+
+def test_favicon_data_url_cache_hit_miss_empty_and_exception(monkeypatch):
+    analyzer = SiteAnalyzer()
+    cache = DummyCache({"icon:example.com": b"hit"})
+    monkeypatch.setattr(analyzer_module, "icon_cache", cache)
+    analyzer.icon_distiller = MagicMock()
+    assert analyzer._favicon_data_url("https://EXAMPLE.com/path") == "data:image/png;base64,aGl0"
+    analyzer.icon_distiller._collect_icon_candidates.assert_not_called()
+
+    cache = DummyCache()
+    monkeypatch.setattr(analyzer_module, "icon_cache", cache)
+    analyzer.icon_distiller._collect_icon_candidates.return_value = ["candidate"]
+    analyzer.icon_distiller._choose_best_icon.return_value = b"chosen"
+    assert analyzer._favicon_data_url("https://new.example") == "data:image/png;base64,Y2hvc2Vu"
+    assert cache.data["icon:new.example"] == b"chosen"
+
+    cache = DummyCache()
+    monkeypatch.setattr(analyzer_module, "icon_cache", cache)
+    analyzer.icon_distiller._choose_best_icon.return_value = None
+    assert analyzer._favicon_data_url("https://empty.example") == ""
+    assert cache.set_calls == []
+
+    cache = MagicMock()
+    cache.get.side_effect = RuntimeError("cache failed")
+    monkeypatch.setattr(analyzer_module, "icon_cache", cache)
+    assert analyzer._favicon_data_url("https://error.example") == ""
+
+
+def test_tracker_detection_keyword_ad_domain_and_clean():
+    analyzer = SiteAnalyzer()
+    assert analyzer._is_tracker("https://cdn.example/analytics.js") is True
+    assert analyzer._is_tracker("https://doubleclick.net/plain.js") is True
+    assert analyzer._is_tracker("https://cdn.example/application.js") is False

--- a/tests/test_coverage_tools.py
+++ b/tests/test_coverage_tools.py
@@ -1,0 +1,255 @@
+import json
+import runpy
+import struct
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from server.tools import backfill_r2, check_android_apk_alignment
+
+
+def _set_tools_root(tmp_path, monkeypatch, *, create_generated=True):
+    root = tmp_path / "project"
+    if create_generated:
+        (root / "generated").mkdir(parents=True)
+    fake_file = root / "server" / "tools" / "backfill_r2.py"
+    monkeypatch.setattr(backfill_r2, "__file__", str(fake_file))
+    return root, root / "generated"
+
+
+def _tool_app(apps_root: Path, app_id: str, recipe=None) -> Path:
+    app = apps_root / app_id
+    app.mkdir(parents=True, exist_ok=True)
+    (app / "recipe.json").write_text(json.dumps(recipe if recipe is not None else {}))
+    return app
+
+
+def _tool_download(app: Path, name="android.apk", data=b"apk") -> Path:
+    downloads = app / "downloads"
+    downloads.mkdir(parents=True, exist_ok=True)
+    path = downloads / name
+    path.write_bytes(data)
+    return path
+
+
+def test_tool_backfill_iter_app_dirs_filters_and_sorts(tmp_path):
+    apps = tmp_path / "generated"
+    _tool_app(apps, "b-app")
+    _tool_app(apps, "a-app")
+
+    assert [path.name for path in backfill_r2._iter_app_dirs(apps, [])] == ["a-app", "b-app"]
+    assert [path.name for path in backfill_r2._iter_app_dirs(apps, ["", "b-app"])] == ["b-app"]
+
+
+def test_tool_backfill_recipe_load_and_save(tmp_path):
+    path = tmp_path / "recipe.json"
+    path.write_text(json.dumps({"id": "app"}))
+    assert backfill_r2._load_recipe(path) == {"id": "app"}
+
+    path.write_text("invalid")
+    assert backfill_r2._load_recipe(path) == {}
+
+    backfill_r2._save_recipe(path, {"name": "Café"})
+    assert json.loads(path.read_text()) == {"name": "Café"}
+    assert "Café" in path.read_text()
+
+
+def test_tool_backfill_main_requires_r2(monkeypatch, capsys):
+    monkeypatch.setattr(backfill_r2.config, "r2_configured", lambda: False)
+    assert backfill_r2.main([]) == 2
+    assert "R2 not configured" in capsys.readouterr().out
+
+
+def test_tool_backfill_main_handles_missing_generated(tmp_path, monkeypatch, capsys):
+    root, apps = _set_tools_root(tmp_path, monkeypatch, create_generated=False)
+    monkeypatch.setattr(backfill_r2.config, "r2_configured", lambda: True)
+
+    assert backfill_r2.main([]) == 0
+    assert not apps.exists()
+    assert f"No generated/ directory at {root / 'generated'}" in capsys.readouterr().out
+
+
+def test_tool_backfill_main_dry_run_covers_all_local_skips(tmp_path, monkeypatch, capsys):
+    _root, apps = _set_tools_root(tmp_path, monkeypatch)
+
+    existing = _tool_app(apps, "existing", {"downloads_cdn": {"android.apk": "https://old/apk"}})
+    _tool_download(existing)
+
+    _tool_app(apps, "no-downloads")
+
+    empty = _tool_app(apps, "empty")
+    (empty / "downloads" / "nested").mkdir(parents=True)
+
+    planned = _tool_app(apps, "planned")
+    _tool_download(planned, "android.apk")
+    _tool_download(planned, "ios.mobileconfig")
+    (planned / "downloads" / "nested").mkdir()
+
+    monkeypatch.setattr(backfill_r2.config, "r2_configured", lambda: True)
+    monkeypatch.setattr(
+        backfill_r2.r2_storage,
+        "upload_app_downloads",
+        lambda *_args: pytest.fail("dry run must not upload"),
+    )
+
+    assert backfill_r2.main(["--dry-run"]) == 0
+    output = capsys.readouterr().out
+    assert "[skip ] existing: already has 1 CDN URLs" in output
+    assert "[skip ] no-downloads: no downloads/ dir" in output
+    assert "[skip ] empty: downloads/ empty" in output
+    assert "[plan ] planned: would upload 2 files" in output
+    assert "apps scanned=4, uploaded=0, skipped=3, dry-run" in output
+
+
+def test_tool_backfill_main_force_filter_upload_outcomes_and_merge(tmp_path, monkeypatch, capsys):
+    _root, apps = _set_tools_root(tmp_path, monkeypatch)
+
+    error = _tool_app(apps, "error")
+    (error / "recipe.json").write_text("not-json")
+    _tool_download(error)
+
+    no_urls = _tool_app(apps, "no-urls")
+    _tool_download(no_urls)
+
+    success = _tool_app(
+        apps,
+        "success",
+        {"downloads_cdn": {"ios.mobileconfig": "https://old/ios"}},
+    )
+    success_recipe = success / "recipe.json"
+    _tool_download(success)
+
+    filtered = _tool_app(apps, "filtered")
+    _tool_download(filtered)
+
+    def upload(app_id, _downloads):
+        if app_id == "error":
+            raise RuntimeError("R2 offline")
+        if app_id == "no-urls":
+            return {}
+        return {"android.apk": "https://cdn.test/success/android.apk"}
+
+    monkeypatch.setattr(backfill_r2.config, "r2_configured", lambda: True)
+    monkeypatch.setattr(backfill_r2.r2_storage, "upload_app_downloads", upload)
+
+    result = backfill_r2.main(
+        ["--force", "--app", "error", "--app", "no-urls", "--app", "success"]
+    )
+
+    assert result == 0
+    assert json.loads(success_recipe.read_text())["downloads_cdn"] == {
+        "ios.mobileconfig": "https://old/ios",
+        "android.apk": "https://cdn.test/success/android.apk",
+    }
+    output = capsys.readouterr().out
+    assert "[error] error: upload failed: R2 offline" in output
+    assert "[skip ] no-urls: nothing uploaded" in output
+    assert "[ok   ] success: uploaded 1 files" in output
+    assert "apps scanned=3, uploaded=1, skipped=1" in output
+    assert "dry-run" not in output
+
+
+def test_tool_backfill_module_entrypoint(monkeypatch):
+    monkeypatch.setattr(backfill_r2.config, "r2_configured", lambda: False)
+    monkeypatch.setattr(sys, "argv", [backfill_r2.__file__])
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(backfill_r2.__file__, run_name="__main__")
+    assert exc_info.value.code == 2
+
+
+def _make_apk(path: Path, entries):
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, compression in entries:
+            zf.writestr(name, b"payload", compress_type=compression)
+
+
+def test_data_offset_reads_local_header_and_rejects_closed_zip(tmp_path):
+    archive = tmp_path / "one.zip"
+    _make_apk(archive, [("entry.txt", zipfile.ZIP_STORED)])
+
+    with zipfile.ZipFile(archive) as zf:
+        info = zf.getinfo("entry.txt")
+        expected = info.header_offset + 30 + len(info.filename.encode()) + len(info.extra)
+        assert check_android_apk_alignment._data_offset(zf, info) == expected
+
+    with pytest.raises(RuntimeError, match="zip file is closed"):
+        check_android_apk_alignment._data_offset(zf, info)
+
+
+def test_check_apk_reports_missing_entries(tmp_path):
+    apk = tmp_path / "empty.apk"
+    _make_apk(apk, [])
+    assert check_android_apk_alignment.check_apk(apk) == [
+        "missing resources.arsc",
+        "missing classes.dex",
+        "missing AndroidManifest.xml",
+    ]
+
+
+def test_check_apk_reports_compression_and_alignment(tmp_path, monkeypatch):
+    apk = tmp_path / "bad.apk"
+    _make_apk(
+        apk,
+        [
+            ("resources.arsc", zipfile.ZIP_DEFLATED),
+            ("classes.dex", zipfile.ZIP_STORED),
+            ("AndroidManifest.xml", zipfile.ZIP_STORED),
+        ],
+    )
+    offsets = {"resources.arsc": 1, "classes.dex": 2, "AndroidManifest.xml": 3}
+    monkeypatch.setattr(
+        check_android_apk_alignment,
+        "_data_offset",
+        lambda _zf, info: offsets[info.filename],
+    )
+
+    assert check_android_apk_alignment.check_apk(apk) == [
+        "resources.arsc is compressed",
+        "resources.arsc offset 1 is not 4-byte aligned",
+        "classes.dex offset 2 is not 4-byte aligned",
+    ]
+
+
+def test_check_apk_accepts_stored_aligned_entries(tmp_path, monkeypatch):
+    apk = tmp_path / "good.apk"
+    _make_apk(
+        apk,
+        [
+            ("resources.arsc", zipfile.ZIP_STORED),
+            ("classes.dex", zipfile.ZIP_STORED),
+            ("AndroidManifest.xml", zipfile.ZIP_STORED),
+        ],
+    )
+    offsets = {"resources.arsc": 4, "classes.dex": 8, "AndroidManifest.xml": 3}
+    monkeypatch.setattr(
+        check_android_apk_alignment,
+        "_data_offset",
+        lambda _zf, info: offsets[info.filename],
+    )
+    assert check_android_apk_alignment.check_apk(apk) == []
+
+
+def test_alignment_main_prints_issues_and_success(tmp_path, monkeypatch, capsys):
+    apk = tmp_path / "app.apk"
+    apk.write_bytes(b"unused because check_apk is mocked")
+
+    monkeypatch.setattr(check_android_apk_alignment, "check_apk", lambda _path: ["bad alignment"])
+    monkeypatch.setattr(sys, "argv", ["check-alignment", str(apk)])
+    assert check_android_apk_alignment.main() == 1
+    assert capsys.readouterr().out == "bad alignment\n"
+
+    monkeypatch.setattr(check_android_apk_alignment, "check_apk", lambda _path: [])
+    assert check_android_apk_alignment.main() == 0
+    assert capsys.readouterr().out == "ok\n"
+
+
+def test_alignment_module_entrypoint(tmp_path, monkeypatch):
+    apk = tmp_path / "empty.apk"
+    _make_apk(apk, [])
+    monkeypatch.setattr(sys, "argv", [check_android_apk_alignment.__file__, str(apk)])
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(check_android_apk_alignment.__file__, run_name="__main__")
+    assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary

Bootstraps the delivery process so every change — from humans or coding agents — follows a consistent Issue → PR → main → CI → merge loop.

## What this adds

- **`.github/workflows/ci.yml`** — the merge gate. Runs `pytest tests/` on Python 3.10 / 3.11 / 3.12 for every push to `main` and every PR. Required check for branch protection: `ci / test (Python 3.11)`. CI **never closes Issues** (Issues close via `Fixes #N` on merge only).
- **`.github/pull_request_template.md`** — Summary / `Fixes #N` / Test plan, auto-filled on new PRs.
- **`AGENTS.md`** — delivery loop + repo guidance for coding agents (the `issue-pr-ci-delivery` skill shape).
- **`CONTRIBUTING.md`** + **`CONTRIBUTING.zh.md`** — the same loop for humans, in EN + zh (matching the repo's existing multilingual docs).

## What this also lands

Two pre-existing coverage suites that were sitting untracked locally and are green:

- `tests/test_coverage_analyzer.py` — **fixed**: adapted to the 5-tuple `_fetch_page` return value introduced in #7 (the auth-provider field), plus a new parametrized `test_fetch_page_stops_at_auth_wall` covering the auth-wall detection from #7.
- `tests/test_coverage_tools.py` — unchanged, 13 tests.

## Test plan

- [x] `pytest tests/test_coverage_analyzer.py tests/test_coverage_tools.py` — 36 passed locally.
- [x] Full tracked suite (+ new coverage suites) — 45 passed.
- [ ] CI on this PR runs `pytest tests/` and should be green on all three Python versions.

## Notes for review

- The remaining untracked coverage suites (`test_coverage_core/scripts/state/storage/signers`) have **pre-existing** failures (tests drifted from implementation over time, unrelated to #7 or this PR). They are intentionally **excluded** here so CI starts green. They should be fixed up and landed in a follow-up PR — tracked separately, not by this Issue.
- Branch protection: after this merges, configure `ci / test (Python 3.11)` as a required check on `main` in repo settings → Branches.

Closes #8