### PR TITLE
feat: HTML 转 App — 上传 .html/.zip 生成五平台应用

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,14 @@ LAUNCH_CACHE_MAX_AGE=60
 OUTBOUND_RESPONSE_MAX_BYTES=4194304
 # Max redirect hops followed for analysis and icon discovery.
 OUTBOUND_REDIRECT_LIMIT=4
+
+# ---------- HTML-to-App uploads ----------
+# Max accepted upload size for .html / .zip HTML app sources.
+HTML_UPLOAD_MAX_BYTES=10485760
+# Max total uncompressed size of an extracted zip site bundle.
+HTML_SITE_MAX_UNCOMPRESSED_BYTES=20971520
+# Max number of files inside an uploaded zip site bundle.
+HTML_SITE_MAX_FILE_COUNT=500
+# Max total site size embedded in an exported history snapshot (larger sites
+# are skipped from the export and flagged instead).
+HTML_EXPORT_MAX_BYTES=2097152

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Open source · Free · No sign-up. Try it live at **[shiaho.sbs](https://shiaho.
 
 ## Features
 
+- **Two input modes**: paste a website URL, or upload your own HTML — a single `.html` file or a `.zip` bundle containing `index.html`. Uploaded HTML is hosted by the server (`/a/<id>/site/...`) and packaged exactly like a URL app.
 - **Site analysis**: fetches the target page and extracts the name, theme color and icon, and counts ads / trackers / popups (display-only estimates).
 - **Multi-platform packaging**: builds installers for five platforms at once
   - **Android** — a real, installable WebView APK (v1+v2+v3 signed). Each app uses its **own dedicated signing certificate**.
@@ -79,6 +80,7 @@ Measured on a real build (figures are representative; they barely vary by site):
 ├── server/
 │   ├── main.py             FastAPI app and routes
 │   ├── config.py           Environment-variable configuration
+│   ├── html_site.py        HTML-upload staging/validation/serving (HTML-to-App)
 │   ├── history_store.py    Per-device history store (JSON)
 │   └── engine/
 │       ├── analyzer.py     Site analysis

--- a/css/style.css
+++ b/css/style.css
@@ -1546,3 +1546,94 @@ section {
 
 .result-note{margin-top:12px;padding:10px 12px;border-radius:10px;background:rgba(201,121,83,.12);color:#8a4b2d;font-size:.92rem;line-height:1.4}
 .result-note.hidden{display:none}
+
+/* ===== Source mode toggle (URL / HTML upload) ===== */
+.source-mode {
+  display: inline-flex;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+  gap: 4px;
+  margin-bottom: 14px;
+}
+
+.mode-btn {
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  padding: 8px 16px;
+  font: inherit;
+  font-size: .88rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+  background: transparent;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.mode-btn:hover {
+  color: var(--ink);
+}
+
+.mode-btn.active {
+  background: var(--accent);
+  color: #fff8f2;
+}
+
+.html-input-wrap.hidden,
+.source-mode + .url-input-wrap.hidden {
+  display: none;
+}
+
+.html-dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 18px 20px;
+  border: 1.5px dashed var(--line-strong);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  cursor: pointer;
+  transition: border-color var(--transition), background var(--transition);
+}
+
+.html-dropzone:hover,
+.html-dropzone.dragover {
+  border-color: var(--accent-warm);
+  background: var(--surface-strong);
+}
+
+.html-dropzone.has-file {
+  border-style: solid;
+  border-color: var(--success);
+}
+
+.html-dropzone-label {
+  font-size: .95rem;
+  font-weight: 600;
+  color: var(--ink);
+  word-break: break-all;
+}
+
+.html-dropzone-hint {
+  font-size: .8rem;
+  color: var(--ink-faint);
+  line-height: 1.5;
+}
+
+.history-badge-html {
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  margin-inline-start: 8px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: rgba(79, 113, 90, 0.14);
+  color: var(--success);
+  font-size: .68rem;
+  font-weight: 700;
+  letter-spacing: .04em;
+  vertical-align: middle;
+}

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -37,6 +37,7 @@
 
 ## 功能
 
+- **两种输入方式**：输入网站链接，或直接上传自己的 HTML——单个 `.html` 文件，或包含 `index.html` 的 `.zip` 压缩包。上传的 HTML 由服务器托管（`/a/<id>/site/...`），打包流程与网址模式完全一致。
 - **站点分析**：抓取目标页面，提取名称、主题色、图标，并统计广告/追踪器/弹窗（展示用估算）。
 - **多平台打包**：一次生成五端安装包
   - **Android** — 真实可安装的 WebView APK（v1+v2+v3 签名）。每个应用使用**独立签名证书**。
@@ -79,6 +80,7 @@
 ├── server/
 │   ├── main.py             FastAPI 应用与路由
 │   ├── config.py           环境变量配置
+│   ├── html_site.py        HTML 上传暂存/校验/托管（HTML 转 App）
 │   ├── history_store.py    设备历史存储（JSON）
 │   └── engine/
 │       ├── analyzer.py     站点分析

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif+SC:wght@400;500;600;700;900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css?v=20260811-opt3">
-  <script src="js/i18n.js?v=20260811-opt3"></script>
-  <script src="js/i18n.strings.js?v=20260811-opt3"></script>
+  <link rel="stylesheet" href="css/style.css?v=20260814-html1">
+  <script src="js/i18n.js?v=20260814-html1"></script>
+  <script src="js/i18n.strings.js?v=20260814-html1"></script>
 </head>
 <body>
   <canvas id="bg"></canvas>
@@ -52,12 +52,26 @@
           <div class="badge" data-i18n="hero.badge">Open source · Free · No sign-up</div>
           <p class="subtitle" data-i18n="hero.subtitle">Enter a link. Seconds later it can be installed, shared and used like an app. From iPhone to desktop, it is the same generated result.</p>
 
-          <div class="url-input-wrap">
+          <div class="source-mode" role="group" aria-label="Source type">
+            <button id="mode-url-btn" class="mode-btn active" type="button" data-i18n="mode.url">Website URL</button>
+            <button id="mode-html-btn" class="mode-btn" type="button" data-i18n="mode.html">HTML file</button>
+          </div>
+
+          <div class="url-input-wrap" id="url-input-wrap">
             <input id="url-input" type="url" data-i18n-placeholder="hero.urlPlaceholder" placeholder="Enter a website link" autocomplete="off" spellcheck="false">
             <button id="distill-btn" type="button">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>
               <span data-i18n="hero.startBtn">Get started</span>
             </button>
+          </div>
+
+          <div class="html-input-wrap hidden" id="html-input-wrap">
+            <input id="html-file-input" class="sr-only" type="file" accept=".html,.htm,.zip">
+            <label for="html-file-input" class="html-dropzone" id="html-dropzone">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>
+              <span class="html-dropzone-label" id="html-file-label" data-i18n="mode.htmlPick">Choose .html or .zip file</span>
+              <small class="html-dropzone-hint" id="html-file-hint" data-i18n="mode.htmlHint">A single HTML file, or a zip containing index.html</small>
+            </label>
           </div>
 
           <div class="stats">
@@ -260,6 +274,6 @@
 
   </main>
 
-  <script src="js/app.v5.js?v=20260811-opt3"></script>
+  <script src="js/app.v5.js?v=20260814-html1"></script>
 </body>
 </html>

--- a/js/app.v5.js
+++ b/js/app.v5.js
@@ -140,7 +140,17 @@
   const historyExportBtn = document.getElementById('history-export-btn');
   const historyImportBtn = document.getElementById('history-import-btn');
   const historyImportInput = document.getElementById('history-import-input');
+  const modeUrlBtn = document.getElementById('mode-url-btn');
+  const modeHtmlBtn = document.getElementById('mode-html-btn');
+  const urlInputWrap = document.getElementById('url-input-wrap');
+  const htmlInputWrap = document.getElementById('html-input-wrap');
+  const htmlFileInput = document.getElementById('html-file-input');
+  const htmlDropzone = document.getElementById('html-dropzone');
+  const htmlFileLabel = document.getElementById('html-file-label');
+  const htmlFileHint = document.getElementById('html-file-hint');
   let currentUrl = '';
+  let inputMode = 'url'; // 'url' | 'html'
+  let htmlFile = null;
   let pendingAutoScrollTimer = null;
   let customIconDataUrl = '';
   let detectedIconDataUrl = '';
@@ -264,6 +274,48 @@
       'Content-Type': 'application/json',
       'X-Device-Fingerprint': deviceFingerprint,
     };
+  }
+
+  // Multipart uploads must not carry a JSON Content-Type; the browser sets
+  // the multipart boundary itself.
+  function apiUploadHeaders() {
+    return { 'X-Device-Fingerprint': deviceFingerprint };
+  }
+
+  function apiErrorMessage(detail, fallbackKey) {
+    if (detail && typeof detail === 'object') {
+      if (detail.code) {
+        const translated = t(detail.code, { msg: detail.message || '' });
+        if (translated !== detail.code) return translated;
+      }
+      if (detail.message) return String(detail.message);
+      return t(fallbackKey);
+    }
+    if (typeof detail === 'string' && detail) return detail;
+    return t(fallbackKey);
+  }
+
+  function setInputMode(mode) {
+    inputMode = mode === 'html' ? 'html' : 'url';
+    modeUrlBtn.classList.toggle('active', inputMode === 'url');
+    modeHtmlBtn.classList.toggle('active', inputMode === 'html');
+    urlInputWrap.classList.toggle('hidden', inputMode === 'html');
+    htmlInputWrap.classList.toggle('hidden', inputMode !== 'html');
+  }
+
+  function formatBytes(bytes) {
+    const n = Number(bytes || 0);
+    if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+    if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
+    return `${n} B`;
+  }
+
+  function resetHtmlFile() {
+    htmlFile = null;
+    htmlFileInput.value = '';
+    htmlDropzone.classList.remove('has-file');
+    htmlFileLabel.textContent = t('mode.htmlPick');
+    htmlFileHint.textContent = t('mode.htmlHint');
   }
 
   async function attachHistoryItem(appId) {
@@ -406,6 +458,10 @@
       const iconHtml = item.icon_url
         ? `<img class="history-icon" src="${escapeHtml(item.icon_url)}" alt="${escapeHtml(item.name || item.app_id)}">`
         : `<div class="history-icon" aria-hidden="true"></div>`;
+      const isHtmlApp = !!(item.recipe && item.recipe.source_type === 'html');
+      const htmlBadge = isHtmlApp
+        ? `<span class="history-badge-html">${escapeHtml(t('history.badgeHtml'))}</span>`
+        : '';
       card.className = 'history-card';
       card._historyItem = item;
       card.innerHTML = `
@@ -413,7 +469,7 @@
           <div class="history-name-row">
             ${iconHtml}
             <div class="history-name-block">
-              <div class="history-name">${escapeHtml(item.name || item.app_id)}</div>
+              <div class="history-name">${escapeHtml(item.name || item.app_id)}${htmlBadge}</div>
               <div class="history-link">${escapeHtml(publicPath)}</div>
             </div>
           </div>
@@ -566,19 +622,39 @@
     if (customIconDataUrl) options['custom-icon-data-url'] = customIconDataUrl;
     Object.assign(options, collectFeatureOptions());
 
-    const submitRes = await fetch('/api/distill', {
-      method: 'POST',
-      headers: apiHeaders(),
-      body: JSON.stringify({
-        url: currentUrl,
-        name: appNameInput.value,
-        color: appColorInput.value,
-        display: 'fullscreen',
-        orientation: 'any',
-        options: options,
-      }),
-    });
-    if (!submitRes.ok) throw new Error(t('err.generateFailed'));
+    let submitRes;
+    if (inputMode === 'html') {
+      if (!htmlFile) throw new Error(t('err.htmlNoFile'));
+      const form = new FormData();
+      form.append('file', htmlFile, htmlFile.name);
+      form.append('name', appNameInput.value);
+      form.append('color', appColorInput.value);
+      form.append('display', 'fullscreen');
+      form.append('orientation', 'any');
+      form.append('options', JSON.stringify(options));
+      submitRes = await fetch('/api/distill/html', {
+        method: 'POST',
+        headers: apiUploadHeaders(),
+        body: form,
+      });
+    } else {
+      submitRes = await fetch('/api/distill', {
+        method: 'POST',
+        headers: apiHeaders(),
+        body: JSON.stringify({
+          url: currentUrl,
+          name: appNameInput.value,
+          color: appColorInput.value,
+          display: 'fullscreen',
+          orientation: 'any',
+          options: options,
+        }),
+      });
+    }
+    if (!submitRes.ok) {
+      const err = await submitRes.json().catch(() => null);
+      throw new Error(apiErrorMessage(err && err.detail, 'err.generateFailed'));
+    }
     const task = await submitRes.json();
     if (!task.task_id) throw new Error(t('err.taskSubmitFailed'));
 
@@ -606,12 +682,12 @@
         });
         if (pollRes.status === 404) throw new Error(t('err.taskMissing'));
         if (!pollRes.ok) {
-          let message = t('err.generateFailed');
+          let message = '';
           try {
             const err = await pollRes.json();
-            if (err && err.detail) message = String(err.detail);
+            message = apiErrorMessage(err && err.detail, 'err.generateFailed');
           } catch (_err) {}
-          throw new Error(message);
+          throw new Error(message || t('err.generateFailed'));
         }
         const payload = await pollRes.json();
         if (payload && payload.status && payload.task_id) {
@@ -710,8 +786,126 @@
   }
 
   // --- Distill Flow ---
-  distillBtn.addEventListener('click', startDistill);
-  urlInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') startDistill(); });
+  distillBtn.addEventListener('click', () => {
+    if (inputMode === 'html') {
+      if (!htmlFile) {
+        alert(t('err.htmlNoFile'));
+        return;
+      }
+      scheduleGentleScroll(workspace, { block: 'start', threshold: 0.55, delay: 120 });
+      return;
+    }
+    startDistill();
+  });
+  urlInput.addEventListener('keydown', (e) => { if (e.key === 'Enter' && inputMode === 'url') startDistill(); });
+  modeUrlBtn.addEventListener('click', () => setInputMode('url'));
+  modeHtmlBtn.addEventListener('click', () => setInputMode('html'));
+  htmlFileInput.addEventListener('change', () => {
+    const file = htmlFileInput.files && htmlFileInput.files[0];
+    if (!file) return;
+    selectHtmlFile(file);
+  });
+  ['dragover', 'dragenter'].forEach((eventName) => {
+    htmlDropzone.addEventListener(eventName, (e) => {
+      e.preventDefault();
+      htmlDropzone.classList.add('dragover');
+    });
+  });
+  ['dragleave', 'drop'].forEach((eventName) => {
+    htmlDropzone.addEventListener(eventName, () => htmlDropzone.classList.remove('dragover'));
+  });
+  htmlDropzone.addEventListener('drop', (e) => {
+    e.preventDefault();
+    const file = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+    if (file) selectHtmlFile(file);
+  });
+
+  async function selectHtmlFile(file) {
+    htmlFile = file;
+    htmlFileLabel.textContent = file.name;
+    htmlFileHint.textContent = `${formatBytes(file.size)} · ${t('mode.htmlHint')}`;
+    htmlDropzone.classList.add('has-file');
+    await startHtmlAnalyze(file);
+  }
+
+  async function startHtmlAnalyze(file) {
+    let data = null;
+    let uploadError = null;
+    try {
+      const form = new FormData();
+      form.append('file', file, file.name);
+      const res = await fetch('/api/analyze/html', {
+        method: 'POST',
+        headers: apiUploadHeaders(),
+        body: form,
+      });
+      if (res.ok) {
+        data = await res.json();
+      } else {
+        const err = await res.json().catch(() => null);
+        uploadError = apiErrorMessage(err && err.detail, 'err.generateFailed');
+      }
+    } catch (_err) {
+      // Network failure: fall through to a local, file-name-only prefill.
+    }
+    if (uploadError) {
+      alert(uploadError);
+      resetHtmlFile();
+      return;
+    }
+    if (!data) {
+      data = {
+        sourceType: 'html',
+        name: file.name.replace(/\.(html?|zip)$/i, ''),
+        color: '',
+        iconDataUrl: '',
+        fileCount: 0,
+        totalBytes: file.size,
+      };
+    }
+    workspace.classList.remove('hidden');
+    resultPanel.classList.add('hidden');
+    showHtmlAnalysisResults(data);
+    scheduleGentleScroll(workspace, { block: 'start', threshold: 0.55, delay: 120 });
+  }
+
+  function showHtmlAnalysisResults(data) {
+    analysisStatus.textContent = t('analysis.statusDone');
+    analysisStatus.className = 'status-badge done';
+    const suggestedName = String(data.name || '').trim()
+      || (htmlFile ? htmlFile.name.replace(/\.(html?|zip)$/i, '') : '');
+    if (suggestedName) {
+      syncInputValue(appNameInput, suggestedName);
+      updateAppNameSourceNote(data.name ? 'title_full' : '', suggestedName);
+    }
+    const themeColor = String(data.color || '').trim();
+    if (/^#[0-9a-fA-F]{3,8}$/.test(themeColor)) {
+      syncInputValue(appColorInput, themeColor);
+      colorHex.textContent = themeColor.toUpperCase();
+    }
+    if (data.iconDataUrl) {
+      detectedIconDataUrl = String(data.iconDataUrl);
+      setRestoreIconState(detectedIconDataUrl, {
+        label: t('icon.autoFetched'),
+        fileName: t('icon.autoFetchedFile'),
+        buttonLabel: t('icon.restoreAutoFetch'),
+      });
+      fillIconPreview(detectedIconDataUrl, t('icon.autoFetched'));
+      if (customIconFileName) customIconFileName.textContent = t('icon.autoFetchedFile');
+    } else {
+      detectedIconDataUrl = '';
+      setRestoreIconState('', {});
+      fillIconPreview('', '');
+    }
+    analysisBody.innerHTML = `
+      <div class="analysis-results">
+        <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.suggestedName'))}</span><span class="value good">${escapeHtml(suggestedName || t('analysis.notSaved'))}</span></div>
+        <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.iconStatus'))}</span><span class="value ${data.iconDataUrl ? 'good' : 'info'}">${escapeHtml(data.iconDataUrl ? t('analysis.iconAutoFetched') : t('analysis.iconNotDetected'))}</span></div>
+        <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.htmlFiles'))}</span><span class="value info">${Number(data.fileCount || 0).toLocaleString(locale())}</span></div>
+        <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.htmlTotalSize'))}</span><span class="value info">${escapeHtml(formatBytes(data.totalBytes || 0))}</span></div>
+        <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.htmlSource'))}</span><span class="value info">${escapeHtml(t('analysis.htmlSourceValue'))}</span></div>
+      </div>`;
+  }
 
   async function startDistill() {
     const raw = urlInput.value.trim();

--- a/js/i18n.strings.js
+++ b/js/i18n.strings.js
@@ -9,6 +9,18 @@
 
   // ---------- English (base / fallback) ----------
   R('en', {
+    'mode.url': 'Website URL',
+    'mode.html': 'HTML file',
+    'mode.htmlPick': 'Choose .html or .zip file',
+    'mode.htmlHint': 'A single HTML file, or a zip containing index.html',
+    'err.htmlNoFile': 'Please choose an .html or .zip file first',
+    'htmlUpload.tooLarge': 'Uploaded file is too large',
+    'htmlUpload.invalid': 'Invalid upload: {msg}',
+    'analysis.htmlFiles': 'Files in package',
+    'analysis.htmlTotalSize': 'Package size',
+    'analysis.htmlSource': 'Source type',
+    'analysis.htmlSourceValue': 'Uploaded HTML',
+    'history.badgeHtml': 'HTML',
     'meta.title': 'WebToApp — Turn websites into apps | Free & Open Source',
     'meta.description': 'Enter a URL and get an app you can install, share and use right away. Works on iPhone, Android, Windows, macOS and Linux.',
     'meta.ogTitle': 'WebToApp — Turn websites into apps',
@@ -186,6 +198,18 @@
 
   // ---------- 简体中文 ----------
   R('zh', {
+    'mode.url': '网站链接',
+    'mode.html': 'HTML 文件',
+    'mode.htmlPick': '选择 .html 或 .zip 文件',
+    'mode.htmlHint': '单个 HTML 文件，或包含 index.html 的 zip 压缩包',
+    'err.htmlNoFile': '请先选择 .html 或 .zip 文件',
+    'htmlUpload.tooLarge': '上传的文件过大',
+    'htmlUpload.invalid': '文件无效：{msg}',
+    'analysis.htmlFiles': '包内文件数',
+    'analysis.htmlTotalSize': '包大小',
+    'analysis.htmlSource': '来源类型',
+    'analysis.htmlSourceValue': '上传的 HTML',
+    'history.badgeHtml': 'HTML',
     'meta.title': 'WebToApp — 把网站做成应用 | 免费开源',
     'meta.description': '输入一个网址，得到一个可以安装、可以分享、可以直接使用的应用。支持 iPhone、Android、Windows、macOS 和 Linux。',
     'meta.ogTitle': 'WebToApp — 把网站做成应用',
@@ -363,6 +387,18 @@
 
   // ---------- 日本語 ----------
   R('ja', {
+    'mode.url': 'ウェブサイトURL',
+    'mode.html': 'HTML ファイル',
+    'mode.htmlPick': '.html または .zip ファイルを選択',
+    'mode.htmlHint': '単一の HTML ファイル、または index.html を含む zip',
+    'err.htmlNoFile': '先に .html または .zip ファイルを選択してください',
+    'htmlUpload.tooLarge': 'ファイルが大きすぎます',
+    'htmlUpload.invalid': '無効なアップロードです：{msg}',
+    'analysis.htmlFiles': 'ファイル数',
+    'analysis.htmlTotalSize': 'パッケージサイズ',
+    'analysis.htmlSource': 'ソース種別',
+    'analysis.htmlSourceValue': 'アップロードされた HTML',
+    'history.badgeHtml': 'HTML',
     'meta.title': 'WebToApp — ウェブサイトをアプリに | 無料・オープンソース',
     'meta.description': 'URL を入力するだけで、インストール・共有・すぐに使えるアプリが手に入ります。iPhone、Android、Windows、macOS、Linux に対応。',
     'meta.ogTitle': 'WebToApp — ウェブサイトをアプリに',
@@ -540,6 +576,18 @@
 
   // ---------- العربية (RTL) ----------
   R('ar', {
+    'mode.url': 'رابط موقع',
+    'mode.html': 'ملف HTML',
+    'mode.htmlPick': 'اختر ملف .html أو .zip',
+    'mode.htmlHint': 'ملف HTML واحد، أو ملف zip يحتوي على index.html',
+    'err.htmlNoFile': 'يرجى اختيار ملف .html أو .zip أولاً',
+    'htmlUpload.tooLarge': 'الملف المرفوع كبير جدًا',
+    'htmlUpload.invalid': 'تحميل غير صالح: {msg}',
+    'analysis.htmlFiles': 'عدد الملفات',
+    'analysis.htmlTotalSize': 'حجم الحزمة',
+    'analysis.htmlSource': 'نوع المصدر',
+    'analysis.htmlSourceValue': 'HTML مرفوع',
+    'history.badgeHtml': 'HTML',
     'meta.title': 'WebToApp — حوّل المواقع إلى تطبيقات | مجاني ومفتوح المصدر',
     'meta.description': 'أدخل رابطًا واحصل على تطبيق يمكنك تثبيته ومشاركته واستخدامه فورًا. يعمل على iPhone وAndroid وWindows وmacOS وLinux.',
     'meta.ogTitle': 'WebToApp — حوّل المواقع إلى تطبيقات',
@@ -717,6 +765,18 @@
 
   // ---------- Русский ----------
   R('ru', {
+    'mode.url': 'Ссылка на сайт',
+    'mode.html': 'HTML-файл',
+    'mode.htmlPick': 'Выберите файл .html или .zip',
+    'mode.htmlHint': 'Один HTML-файл или zip с index.html внутри',
+    'err.htmlNoFile': 'Сначала выберите файл .html или .zip',
+    'htmlUpload.tooLarge': 'Файл слишком большой',
+    'htmlUpload.invalid': 'Недопустимая загрузка: {msg}',
+    'analysis.htmlFiles': 'Файлов в пакете',
+    'analysis.htmlTotalSize': 'Размер пакета',
+    'analysis.htmlSource': 'Тип источника',
+    'analysis.htmlSourceValue': 'Загруженный HTML',
+    'history.badgeHtml': 'HTML',
     'meta.title': 'WebToApp — Превратите сайты в приложения | Бесплатно и с открытым кодом',
     'meta.description': 'Введите URL и получите приложение, которое можно установить, поделиться им и сразу использовать. Работает на iPhone, Android, Windows, macOS и Linux.',
     'meta.ogTitle': 'WebToApp — Превратите сайты в приложения',
@@ -894,6 +954,18 @@
 
   // ---------- Español ----------
   R('es', {
+    'mode.url': 'URL del sitio',
+    'mode.html': 'Archivo HTML',
+    'mode.htmlPick': 'Elija un archivo .html o .zip',
+    'mode.htmlHint': 'Un solo archivo HTML, o un zip que contenga index.html',
+    'err.htmlNoFile': 'Elija primero un archivo .html o .zip',
+    'htmlUpload.tooLarge': 'El archivo subido es demasiado grande',
+    'htmlUpload.invalid': 'Subida no válida: {msg}',
+    'analysis.htmlFiles': 'Archivos en el paquete',
+    'analysis.htmlTotalSize': 'Tamaño del paquete',
+    'analysis.htmlSource': 'Tipo de origen',
+    'analysis.htmlSourceValue': 'HTML subido',
+    'history.badgeHtml': 'HTML',
     'meta.title': 'WebToApp — Convierte sitios web en aplicaciones | Gratis y de código abierto',
     'meta.description': 'Introduce una URL y obtén una app que puedes instalar, compartir y usar al instante. Funciona en iPhone, Android, Windows, macOS y Linux.',
     'meta.ogTitle': 'WebToApp — Convierte sitios web en aplicaciones',
@@ -1071,6 +1143,18 @@
 
   // ---------- Português ----------
   R('pt', {
+    'mode.url': 'URL do site',
+    'mode.html': 'Arquivo HTML',
+    'mode.htmlPick': 'Escolha um arquivo .html ou .zip',
+    'mode.htmlHint': 'Um único arquivo HTML, ou um zip contendo index.html',
+    'err.htmlNoFile': 'Escolha primeiro um arquivo .html ou .zip',
+    'htmlUpload.tooLarge': 'O arquivo enviado é muito grande',
+    'htmlUpload.invalid': 'Envio inválido: {msg}',
+    'analysis.htmlFiles': 'Arquivos no pacote',
+    'analysis.htmlTotalSize': 'Tamanho do pacote',
+    'analysis.htmlSource': 'Tipo de origem',
+    'analysis.htmlSourceValue': 'HTML enviado',
+    'history.badgeHtml': 'HTML',
     'meta.title': 'WebToApp — Transforme sites em aplicativos | Grátis e código aberto',
     'meta.description': 'Insira uma URL e obtenha um app que você pode instalar, compartilhar e usar na hora. Funciona em iPhone, Android, Windows, macOS e Linux.',
     'meta.ogTitle': 'WebToApp — Transforme sites em aplicativos',
@@ -1248,6 +1332,18 @@
 
   // ---------- Français ----------
   R('fr', {
+    'mode.url': 'URL du site',
+    'mode.html': 'Fichier HTML',
+    'mode.htmlPick': 'Choisir un fichier .html ou .zip',
+    'mode.htmlHint': 'Un seul fichier HTML, ou un zip contenant index.html',
+    'err.htmlNoFile': 'Choisissez d\'abord un fichier .html ou .zip',
+    'htmlUpload.tooLarge': 'Le fichier téléversé est trop volumineux',
+    'htmlUpload.invalid': 'Téléversement invalide : {msg}',
+    'analysis.htmlFiles': 'Fichiers dans le paquet',
+    'analysis.htmlTotalSize': 'Taille du paquet',
+    'analysis.htmlSource': 'Type de source',
+    'analysis.htmlSourceValue': 'HTML téléversé',
+    'history.badgeHtml': 'HTML',
     'meta.title': 'WebToApp — Transformez les sites web en applications | Gratuit et open source',
     'meta.description': 'Saisissez une URL et obtenez une application que vous pouvez installer, partager et utiliser immédiatement. Fonctionne sur iPhone, Android, Windows, macOS et Linux.',
     'meta.ogTitle': 'WebToApp — Transformez les sites web en applications',
@@ -1425,6 +1521,18 @@
 
   // ---------- Deutsch ----------
   R('de', {
+    'mode.url': 'Website-URL',
+    'mode.html': 'HTML-Datei',
+    'mode.htmlPick': '.html- oder .zip-Datei wählen',
+    'mode.htmlHint': 'Eine einzelne HTML-Datei oder ein Zip mit index.html',
+    'err.htmlNoFile': 'Bitte zuerst eine .html- oder .zip-Datei wählen',
+    'htmlUpload.tooLarge': 'Die hochgeladene Datei ist zu groß',
+    'htmlUpload.invalid': 'Ungültiger Upload: {msg}',
+    'analysis.htmlFiles': 'Dateien im Paket',
+    'analysis.htmlTotalSize': 'Paketgröße',
+    'analysis.htmlSource': 'Quelltyp',
+    'analysis.htmlSourceValue': 'Hochgeladenes HTML',
+    'history.badgeHtml': 'HTML',
     'meta.title': 'WebToApp — Websites in Apps verwandeln | Kostenlos & Open Source',
     'meta.description': 'Gib eine URL ein und erhalte eine App, die du installieren, teilen und sofort nutzen kannst. Funktioniert auf iPhone, Android, Windows, macOS und Linux.',
     'meta.ogTitle': 'WebToApp — Websites in Apps verwandeln',

--- a/server/config.py
+++ b/server/config.py
@@ -177,6 +177,46 @@ def trusted_proxy_cidrs() -> list[str]:
     return values or ["127.0.0.1/32", "::1/128"]
 
 
+# ---------- HTML-to-App uploads ----------
+#
+# Uploaded HTML content (.html single file or .zip site bundle) is hosted by
+# this server under generated/<app_id>/site/ and served via /a/{id}/site/.
+# These caps bound disk usage and the zip-decompression attack surface.
+
+def html_upload_max_bytes() -> int:
+    """Maximum accepted request body for an HTML upload (compressed zip size
+    counts against this too). Default 10 MB."""
+    try:
+        return max(64 * 1024, int(os.environ.get("HTML_UPLOAD_MAX_BYTES", str(10 * 1024 * 1024)).strip()))
+    except ValueError:
+        return 10 * 1024 * 1024
+
+
+def html_site_max_uncompressed_bytes() -> int:
+    """Maximum total uncompressed size of an extracted zip site bundle. Default 20 MB."""
+    try:
+        return max(64 * 1024, int(os.environ.get("HTML_SITE_MAX_UNCOMPRESSED_BYTES", str(20 * 1024 * 1024)).strip()))
+    except ValueError:
+        return 20 * 1024 * 1024
+
+
+def html_site_max_file_count() -> int:
+    """Maximum number of files inside an uploaded zip site bundle. Default 500."""
+    try:
+        return max(1, int(os.environ.get("HTML_SITE_MAX_FILE_COUNT", "500").strip() or "500"))
+    except ValueError:
+        return 500
+
+
+def html_export_max_bytes() -> int:
+    """Maximum total site size embedded in an exported history snapshot.
+    Larger sites are skipped from the export and flagged instead. Default 2 MB."""
+    try:
+        return max(0, int(os.environ.get("HTML_EXPORT_MAX_BYTES", str(2 * 1024 * 1024)).strip()))
+    except ValueError:
+        return 2 * 1024 * 1024
+
+
 # ---------- Cloudflare R2 (S3-compatible) ----------
 #
 # Set ALL of the following to enable R2 offload. Once configured, every

--- a/server/engine/distiller.py
+++ b/server/engine/distiller.py
@@ -23,6 +23,7 @@ from server.engine.apk_builder import ApkBuilder
 from server.engine import mobileconfig_signer
 from server.engine.cache import html_cache, icon_cache
 from server.engine.storage import r2_storage
+from server import html_site
 from server.htmlmeta import parse_html_metadata
 from server.logging_util import log_event
 from server.net import fetch_public_url_bytes
@@ -37,15 +38,17 @@ class Distiller:
     _FEATURE_DOWNLOAD_DIR_VALUES = {"public_downloads", "app_folder"}
     _FEATURE_PERMISSION_VALUES = {"prompt", "deny"}
 
-    def create_recipe(self, app_id, url, name, color, display, orientation, options):
+    def create_recipe(self, app_id, url, name, color, display, orientation, options,
+                      source_type="url", content_hash=None):
         clean_name = name or url.split("//")[-1].split("/")[0].replace("www.", "")
         version_code = self._android_version_code(app_id, options)
         version_name = self._android_version_name(options)
         package_prefix = self._android_package_prefix(options)
         feature_options = self._feature_options(options)
-        return {
+        recipe = {
             "id": app_id, "url": url, "name": clean_name,
             "color": color, "display": display, "orientation": orientation,
+            "source_type": source_type or "url",
             "android_version_code": version_code,
             "android_version_name": version_name,
             "android_package_prefix": package_prefix,
@@ -54,6 +57,9 @@ class Distiller:
             "edit_token": self._edit_token(app_id),
             "options": feature_options,
         }
+        if recipe["source_type"] == "html":
+            recipe["content_hash"] = content_hash or ""
+        return recipe
 
     def _edit_token(self, app_id):
         """Secret token gating URL hot-swaps for this app. Stable per app_id:
@@ -281,6 +287,10 @@ class Distiller:
         custom_icon = self._custom_icon_png(recipe.get("_custom_icon_data_url"))
         if custom_icon:
             return custom_icon
+        if recipe.get("source_type") == "html":
+            # Content is local: custom icon > favicon declared in the uploaded
+            # HTML > solid-color placeholder. No network fallback.
+            return self._local_site_icon(recipe) or self._make_placeholder_png(recipe.get("color", "#7c3aed"))
         url = recipe["url"]
         host = urlparse(url).netloc.lower()
         cache_key = f"icon:{host}"
@@ -293,6 +303,17 @@ class Distiller:
             icon_cache.set(cache_key, best)
             return best
         return self._make_placeholder_png(recipe.get("color", "#7c3aed"))
+
+    def _local_site_icon(self, recipe):
+        """Favicon extracted from the staged HTML bundle (PNG or ICO → PNG)."""
+        site_dir = self._generated_root() / recipe["id"] / "site"
+        if not site_dir.is_dir():
+            return None
+        meta = html_site.extract_site_meta(site_dir)
+        raw = meta.get("icon_png")
+        if not raw:
+            return None
+        return self._normalize_to_png(raw)
 
     def _custom_icon_png(self, data_url):
         if not data_url:
@@ -565,7 +586,9 @@ class Distiller:
     def render_download_page(self, app_dir: Path, r: dict) -> str:
         base = f"/a/{r['id']}"
         parsed = urlparse(r["url"])
-        source_host = parsed.netloc.replace("www.", "") or r["url"]
+        is_html_app = r.get("source_type") == "html"
+        source_host = "HTML App" if is_html_app else (parsed.netloc.replace("www.", "") or r["url"])
+        open_site_key = "openApp" if is_html_app else "openSite"
         favicon = f"{base}/icon.png" if (app_dir / "icon.png").exists() \
             else f"https://www.google.com/s2/favicons?domain={parsed.netloc}&sz=128"
         cfg = app_dir / "downloads" / "ios.mobileconfig"
@@ -774,7 +797,7 @@ a{{color:inherit;text-decoration:none}}
           </div>
         </div>
         <div class="app-actions">
-          <a class="action primary" href="{r['url']}" target="_blank" rel="noopener noreferrer" data-i18n="openSite">Open original site</a>
+          <a class="action primary" href="{r['url']}" target="_blank" rel="noopener noreferrer" data-i18n="{open_site_key}">Open original site</a>
           <a class="action" href="{base}/download/ios" data-i18n="downloadIosProfile">Download iPhone profile</a>
         </div>
       </div>
@@ -850,6 +873,7 @@ a{{color:inherit;text-decoration:none}}
                 "heroDesc": "This is not an app store page, just this site's install entry. Pick your device, then download to install, unzip, or add to the iPhone home screen.",
                 "appSub": "The multi-platform installers and config profile generated for this site. You can send this page directly to users without explaining the download paths.",
                 "openSite": "Open original site",
+                "openApp": "Open app",
                 "downloadIosProfile": "Download iPhone profile",
                 "iosTitle": "iPhone install guide",
                 "iosBadgeSigned": "Signed",
@@ -883,6 +907,7 @@ a{{color:inherit;text-decoration:none}}
                 "heroDesc": "这不是一个市场页，只是这个网站的安装入口。选好你的设备，下载后就可以直接安装、解压，或者在 iPhone 上添加到主屏幕。",
                 "appSub": "为当前站点生成的多端安装包与安装描述文件。你可以直接把这个页面发给用户，不需要再解释下载路径。",
                 "openSite": "打开原站",
+                "openApp": "打开应用",
                 "downloadIosProfile": "下载 iPhone 描述文件",
                 "iosTitle": "iPhone 安装说明",
                 "iosBadgeSigned": "已签名",
@@ -916,6 +941,7 @@ a{{color:inherit;text-decoration:none}}
                 "heroDesc": "これはアプリストアのページではなく、このサイトのインストール入口です。デバイスを選び、ダウンロードしてインストール・解凍、または iPhone のホーム画面に追加してください。",
                 "appSub": "このサイト向けに生成したマルチプラットフォームのインストーラーと構成プロファイルです。このページをそのままユーザーに送れます。ダウンロード手順を説明する必要はありません。",
                 "openSite": "元のサイトを開く",
+                "openApp": "アプリを開く",
                 "downloadIosProfile": "iPhone プロファイルをダウンロード",
                 "iosTitle": "iPhone インストール手順",
                 "iosBadgeSigned": "署名済み",
@@ -949,6 +975,7 @@ a{{color:inherit;text-decoration:none}}
                 "heroDesc": "هذه ليست صفحة متجر تطبيقات، بل مجرد مدخل التثبيت لهذا الموقع. اختر جهازك، ثم نزّل للتثبيت أو فك الضغط أو الإضافة إلى الشاشة الرئيسية في iPhone.",
                 "appSub": "حِزم التثبيت متعددة المنصات وملف التهيئة المُولّدة لهذا الموقع. يمكنك إرسال هذه الصفحة مباشرةً إلى المستخدمين دون شرح مسارات التنزيل.",
                 "openSite": "فتح الموقع الأصلي",
+                "openApp": "فتح التطبيق",
                 "downloadIosProfile": "تنزيل ملف تعريف iPhone",
                 "iosTitle": "دليل تثبيت iPhone",
                 "iosBadgeSigned": "موقّع",
@@ -982,6 +1009,7 @@ a{{color:inherit;text-decoration:none}}
                 "heroDesc": "Это не страница магазина приложений, а просто точка установки этого сайта. Выберите устройство, затем скачайте, чтобы установить, распаковать или добавить на главный экран iPhone.",
                 "appSub": "Кроссплатформенные установщики и профиль конфигурации, созданные для этого сайта. Эту страницу можно отправлять пользователям без объяснения путей загрузки.",
                 "openSite": "Открыть исходный сайт",
+                "openApp": "Открыть приложение",
                 "downloadIosProfile": "Скачать профиль iPhone",
                 "iosTitle": "Инструкция по установке на iPhone",
                 "iosBadgeSigned": "Подписано",
@@ -1015,6 +1043,7 @@ a{{color:inherit;text-decoration:none}}
                 "heroDesc": "Esta no es una página de tienda de apps, solo la entrada de instalación de este sitio. Elige tu dispositivo y descarga para instalar, descomprimir o añadir a la pantalla de inicio del iPhone.",
                 "appSub": "Los instaladores multiplataforma y el perfil de configuración generados para este sitio. Puedes enviar esta página directamente a los usuarios sin explicar las rutas de descarga.",
                 "openSite": "Abrir sitio original",
+                "openApp": "Abrir aplicación",
                 "downloadIosProfile": "Descargar perfil de iPhone",
                 "iosTitle": "Guía de instalación en iPhone",
                 "iosBadgeSigned": "Firmado",
@@ -1048,6 +1077,7 @@ a{{color:inherit;text-decoration:none}}
                 "heroDesc": "Esta não é uma página de loja de apps, apenas a entrada de instalação deste site. Escolha seu dispositivo e baixe para instalar, descompactar ou adicionar à tela inicial do iPhone.",
                 "appSub": "Os instaladores multiplataforma e o perfil de configuração gerados para este site. Você pode enviar esta página diretamente aos usuários sem explicar os caminhos de download.",
                 "openSite": "Abrir site original",
+                "openApp": "Abrir aplicativo",
                 "downloadIosProfile": "Baixar perfil do iPhone",
                 "iosTitle": "Guia de instalação no iPhone",
                 "iosBadgeSigned": "Assinado",
@@ -1081,6 +1111,7 @@ a{{color:inherit;text-decoration:none}}
                 "heroDesc": "Ce n'est pas une page de boutique d'applications, juste le point d'installation de ce site. Choisissez votre appareil, puis téléchargez pour installer, décompresser ou ajouter à l'écran d'accueil de l'iPhone.",
                 "appSub": "Les installateurs multiplateformes et le profil de configuration générés pour ce site. Vous pouvez envoyer cette page directement aux utilisateurs sans expliquer les chemins de téléchargement.",
                 "openSite": "Ouvrir le site d'origine",
+                "openApp": "Ouvrir l'application",
                 "downloadIosProfile": "Télécharger le profil iPhone",
                 "iosTitle": "Guide d'installation iPhone",
                 "iosBadgeSigned": "Signé",
@@ -1114,6 +1145,7 @@ a{{color:inherit;text-decoration:none}}
                 "heroDesc": "Dies ist keine App-Store-Seite, nur der Installationseinstieg dieser Website. Wähle dein Gerät und lade herunter, um zu installieren, zu entpacken oder zum iPhone-Startbildschirm hinzuzufügen.",
                 "appSub": "Die plattformübergreifenden Installer und das Konfigurationsprofil, die für diese Website erstellt wurden. Du kannst diese Seite direkt an Nutzer senden, ohne die Download-Pfade zu erklären.",
                 "openSite": "Originalseite öffnen",
+                "openApp": "App öffnen",
                 "downloadIosProfile": "iPhone-Profil herunterladen",
                 "iosTitle": "iPhone-Installationsanleitung",
                 "iosBadgeSigned": "Signiert",

--- a/server/html_site.py
+++ b/server/html_site.py
@@ -1,0 +1,381 @@
+"""
+HTML site staging & serving helpers for the HTML-to-App feature.
+
+An "HTML app" bundles its content on this server: the upload (a single
+``.html`` file or a ``.zip`` site bundle) is validated, extracted under
+``generated/<app_id>/site/`` and later served from ``/a/{app_id}/site/...``.
+Every validation here treats the upload as hostile input — zip-slip,
+zip bombs and oversized bundles must be rejected before anything is
+written to disk.
+"""
+
+import base64
+import hashlib
+import io
+import re
+import shutil
+import zipfile
+from pathlib import Path
+from typing import Dict, List, Optional
+from urllib.parse import unquote, urlparse
+
+from server import config
+from server.htmlmeta import parse_html_metadata
+
+INDEX_NAME = "index.html"
+
+# Entries that are archive junk rather than site content.
+_JUNK_SEGMENTS = {"__MACOSX", ".DS_Store", "Thumbs.db"}
+
+_MIME_TYPES = {
+    ".html": "text/html; charset=utf-8",
+    ".htm": "text/html; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".mjs": "text/javascript; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".txt": "text/plain; charset=utf-8",
+    ".xml": "application/xml; charset=utf-8",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".svg": "image/svg+xml",
+    ".ico": "image/x-icon",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ttf": "font/ttf",
+    ".otf": "font/otf",
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".ogg": "audio/ogg",
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".wasm": "application/wasm",
+    ".pdf": "application/pdf",
+}
+
+# zip-bomb heuristic: reject entries whose compression ratio exceeds this
+# once the uncompressed size is large enough for the ratio to be meaningful.
+_MAX_COMPRESSION_RATIO = 100
+_RATIO_MIN_FILE_SIZE = 1024 * 1024
+
+
+class HtmlUploadError(ValueError):
+    """Upload failed validation. The message is user-facing (translated client-side by key where possible)."""
+
+
+def _normalized_entry_name(raw: str) -> str:
+    """Normalize a zip entry name; return "" for entries to skip, raise on unsafe ones."""
+    name = raw.replace("\\", "/")
+    while name.startswith("./"):
+        name = name[2:]
+    if not name or name.endswith("/"):
+        return ""  # directory entry
+    if name.startswith("/"):
+        raise HtmlUploadError("Archive contains an absolute path")
+    if re.match(r"^[A-Za-z]:", name):
+        raise HtmlUploadError("Archive contains a drive-qualified path")
+    parts = name.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        raise HtmlUploadError("Archive contains an unsafe path")
+    if any(part in _JUNK_SEGMENTS for part in parts):
+        return ""
+    return "/".join(parts)
+
+
+def _read_capped(zin: zipfile.ZipFile, info: zipfile.ZipInfo, cap: int) -> bytes:
+    """Read one entry, enforcing the advertised size cap even if the local
+    header lies about it."""
+    chunks = []
+    total = 0
+    with zin.open(info, "r") as stream:
+        while True:
+            chunk = stream.read(64 * 1024)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > cap:
+                raise HtmlUploadError("Archive is larger than allowed once extracted")
+            chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _extract_zip(data: bytes, dest: Path) -> List[str]:
+    """Extract an in-memory zip into ``dest`` (created, must not exist yet).
+
+    Applies zip-slip / bomb / count defenses and flattens a single shared
+    top-level directory. Returns the written relative paths.
+    """
+    max_files = config.html_site_max_file_count()
+    max_bytes = config.html_site_max_uncompressed_bytes()
+    try:
+        zin = zipfile.ZipFile(io.BytesIO(data))
+    except zipfile.BadZipFile as exc:
+        raise HtmlUploadError("File is not a valid zip archive") from exc
+    with zin:
+        infos = zin.infolist()
+        if len(infos) > max_files * 2 + 16:
+            raise HtmlUploadError(f"Archive has too many entries (max {max_files} files)")
+        entries: Dict[str, bytes] = {}
+        total = 0
+        for info in infos:
+            if info.flag_bits & 0x1:
+                raise HtmlUploadError("Encrypted archive entries are not supported")
+            name = _normalized_entry_name(info.filename)
+            if not name:
+                continue
+            if info.file_size > max_bytes:
+                raise HtmlUploadError("Archive is larger than allowed once extracted")
+            if (
+                info.file_size > _RATIO_MIN_FILE_SIZE
+                and info.compress_size > 0
+                and info.file_size / info.compress_size > _MAX_COMPRESSION_RATIO
+            ):
+                raise HtmlUploadError("Archive looks like a zip bomb")
+            total += info.file_size
+            if total > max_bytes:
+                raise HtmlUploadError("Archive is larger than allowed once extracted")
+            entries[name] = _read_capped(zin, info, max_bytes)
+        if len(entries) > max_files:
+            raise HtmlUploadError(f"Archive has too many files (max {max_files})")
+        if not entries:
+            raise HtmlUploadError("Archive is empty")
+        entries = _flatten_single_root(entries)
+        if INDEX_NAME not in entries:
+            raise HtmlUploadError(f"Archive must contain {INDEX_NAME} at its root")
+        dest.mkdir(parents=True, exist_ok=False)
+        for name, blob in sorted(entries.items()):
+            target = _contained_path(dest, name)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(blob)
+        return sorted(entries)
+
+
+class _BytesReader(io.BytesIO):
+    """zipfile needs a file-like object; plain BytesIO already qualifies."""
+
+
+def _flatten_single_root(entries: Dict[str, bytes]) -> Dict[str, bytes]:
+    """``mysite/index.html`` … → ``index.html`` … when every entry lives under
+    one shared top-level directory and nothing sits at the root."""
+    first_parts = {name.split("/", 1)[0] for name in entries}
+    if len(first_parts) != 1:
+        return entries
+    if not all("/" in name for name in entries):
+        return entries  # a file at the root level: keep the layout as-is
+    prefix = next(iter(first_parts)) + "/"
+    return {name[len(prefix):]: blob for name, blob in entries.items()}
+
+
+def _contained_path(root: Path, rel: str) -> Path:
+    """Join and verify the result stays inside ``root`` (defense in depth for
+    path traversal; entries are pre-validated but callers may pass raw input)."""
+    candidate = (root / rel).resolve()
+    root_resolved = root.resolve()
+    if candidate != root_resolved and root_resolved not in candidate.parents:
+        raise HtmlUploadError("Path escapes the site directory")
+    return candidate
+
+
+def _hash_content(entries: Dict[str, bytes]) -> str:
+    digest = hashlib.sha256()
+    for name in sorted(entries):
+        digest.update(name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(entries[name]).digest())
+    return digest.hexdigest()
+
+
+def validate_and_extract(data: bytes, filename: str, dest: Path) -> dict:
+    """Validate an HTML upload and write it to ``dest`` (must not exist yet).
+
+    Returns ``{"content_hash", "index_name", "file_count", "total_bytes"}``.
+    Raises :class:`HtmlUploadError` with a user-facing message; nothing is
+    written to disk when validation fails.
+    """
+    if not data:
+        raise HtmlUploadError("Uploaded file is empty")
+    if len(data) > config.html_upload_max_bytes():
+        raise HtmlUploadError("Uploaded file is too large")
+
+    suffix = Path(str(filename or "")).suffix.lower()
+    if suffix in (".html", ".htm"):
+        dest.mkdir(parents=True, exist_ok=False)
+        (dest / INDEX_NAME).write_bytes(data)
+        entries = {INDEX_NAME: data}
+        return {
+            "content_hash": _hash_content(entries),
+            "index_name": INDEX_NAME,
+            "file_count": 1,
+            "total_bytes": len(data),
+        }
+    if suffix == ".zip":
+        names = _extract_zip(data, dest)
+        entries = {name: (dest / name).read_bytes() for name in names}
+        return {
+            "content_hash": _hash_content(entries),
+            "index_name": INDEX_NAME,
+            "file_count": len(entries),
+            "total_bytes": sum(len(blob) for blob in entries.values()),
+        }
+    raise HtmlUploadError("Only .html, .htm and .zip uploads are supported")
+
+
+def app_id_for(content_hash: str, name: str) -> str:
+    """Stable app id for an HTML upload — mirrors the URL flow's md5(url:name).
+    Same content + same name rebuilds the same app (version bump, keystore reuse)."""
+    return hashlib.md5(f"{content_hash}:{name}".encode()).hexdigest()[:8]
+
+
+def stage_html_app(data: bytes, filename: str, name: str, apps_dir: Path) -> dict:
+    """Stage an upload under ``apps_dir/<app_id>/site/`` and return staging info.
+
+    On validation failure nothing is left behind. On success a pre-existing
+    site directory (a rebuild of the same app) is replaced atomically enough
+    for our purposes: extract to a sibling temp dir, then swap.
+    """
+    fallback_name = re.sub(r"[^A-Za-z0-9._-]+", " ", Path(str(filename or "app")).stem).strip() or "app"
+    clean_name = str(name or "").strip() or fallback_name
+    probe = apps_dir / f".stage-{hashlib.md5(data).hexdigest()[:12]}"
+    if probe.exists():
+        shutil.rmtree(probe, ignore_errors=True)
+    try:
+        info = validate_and_extract(data, filename, probe)
+        app_id = app_id_for(info["content_hash"], clean_name)
+        site_dir = apps_dir / app_id / "site"
+        if site_dir.exists():
+            shutil.rmtree(site_dir)
+        site_dir.parent.mkdir(parents=True, exist_ok=True)
+        probe.replace(site_dir)
+        info.update({"app_id": app_id, "name": clean_name, "site_dir": site_dir})
+        return info
+    except Exception:
+        shutil.rmtree(probe, ignore_errors=True)
+        raise
+
+
+def resolve_site_file(site_dir: Path, rel_path: str) -> Optional[Path]:
+    """Resolve a served path inside a site dir; directories fall back to
+    ``index.html``. Returns None when the path does not exist or escapes."""
+    cleaned = str(rel_path or "").lstrip("/")
+    if not cleaned or "\x00" in cleaned:
+        cleaned = INDEX_NAME
+    try:
+        candidate = _contained_path(site_dir, cleaned)
+    except HtmlUploadError:
+        return None
+    if candidate.is_dir():
+        candidate = candidate / INDEX_NAME
+        if not candidate.is_file():
+            return None
+    if not candidate.is_file():
+        return None
+    return candidate
+
+
+def mime_for(path: Path) -> str:
+    return _MIME_TYPES.get(path.suffix.lower(), "application/octet-stream")
+
+
+# ---------- Site metadata (shared by /api/analyze/html and the distiller) ----------
+
+_ICON_RELS = ("apple-touch-icon", "apple-touch-icon-precomposed", "icon")
+_ICON_FALLBACK_NAMES = ("apple-touch-icon.png", "apple-touch-icon-precomposed.png", "favicon.png", "favicon.ico")
+
+
+def _looks_like_image(blob: bytes) -> bool:
+    """Cheap magic check: only PNG / ICO / JPEG / GIF / WebP blobs pass. Keeps
+    truncated or corrupt data URLs out of the icon pipeline."""
+    if not blob or len(blob) < 12:
+        return False
+    if blob[:4] == b"\x89PNG" or blob[:4] == b"\x00\x00\x01\x00":
+        return True
+    if blob[:3] == b"\xff\xd8\xff" or blob[:4] == b"GIF8":
+        return True
+    return blob[:4] == b"RIFF" and blob[8:12] == b"WEBP"
+
+
+def _icon_bytes_from_href(href: str, site_dir: Path) -> Optional[bytes]:
+    """Resolve a declared favicon href to raw bytes: inline data URLs and
+    files bundled inside the site. Remote URLs are ignored (no network here)."""
+    href = str(href or "").strip()
+    if not href:
+        return None
+    if href.startswith("data:"):
+        try:
+            _, b64 = href.split(",", 1)
+            blob = base64.b64decode(b64, validate=False)
+        except Exception:
+            return None
+        return blob if _looks_like_image(blob) else None
+    if href.startswith(("http://", "https://", "//")):
+        return None
+    try:
+        rel = unquote(urlparse(href).path).lstrip("/")
+        blob = _contained_path(site_dir, rel).read_bytes()
+    except (HtmlUploadError, OSError):
+        return None
+    return blob if _looks_like_image(blob) else None
+
+
+def extract_site_meta(site_dir: Path) -> dict:
+    """Local-only metadata for a staged site: ``<title>``, theme-color and
+    the best declared favicon (raw PNG/ICO bytes). Never touches the network."""
+    index = site_dir / INDEX_NAME
+    try:
+        html = index.read_text(errors="ignore")
+    except OSError:
+        html = ""
+    doc = parse_html_metadata(html)
+    icon_png = None
+    for rel in _ICON_RELS:
+        for attrs in doc.link_attrs_by_rel(rel):
+            icon_png = _icon_bytes_from_href(attrs.get("href", ""), site_dir)
+            if icon_png:
+                break
+        if icon_png:
+            break
+    if not icon_png:
+        for name in _ICON_FALLBACK_NAMES:
+            candidate = site_dir / name
+            if candidate.is_file():
+                icon_png = candidate.read_bytes()
+                break
+    theme_color = doc.meta_content("theme-color")
+    return {"title": doc.title, "theme_color": theme_color, "icon_png": icon_png}
+
+
+def iter_site_files(site_dir: Path) -> List[dict]:
+    """All site files as ``{"name": relpath, "data": bytes}`` (sorted)."""
+    files = []
+    for path in sorted(site_dir.rglob("*")):
+        if path.is_file() and site_dir.resolve() in path.resolve().parents:
+            files.append({"name": path.relative_to(site_dir).as_posix(), "data": path.read_bytes()})
+    return files
+
+
+def restore_site_files(site_dir: Path, files: List[dict]) -> None:
+    """Re-create a site directory from an exported snapshot. Same caps as a
+    fresh upload apply — an imported snapshot is just as untrusted."""
+    max_files = config.html_site_max_file_count()
+    max_bytes = config.html_site_max_uncompressed_bytes()
+    if len(files) > max_files:
+        raise HtmlUploadError(f"Snapshot has too many files (max {max_files})")
+    if sum(len(f.get("data") or b"") for f in files) > max_bytes:
+        raise HtmlUploadError("Snapshot is larger than allowed")
+    if site_dir.exists():
+        shutil.rmtree(site_dir)
+    site_dir.mkdir(parents=True, exist_ok=True)
+    for item in files:
+        name = str(item.get("name") or "")
+        blob = bytes(item.get("data") or b"")
+        if not name or name != _normalized_entry_name(name):
+            raise HtmlUploadError("Snapshot contains an unsafe path")
+        target = _contained_path(site_dir, name)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(blob)
+    if not (site_dir / INDEX_NAME).is_file():
+        shutil.rmtree(site_dir, ignore_errors=True)
+        raise HtmlUploadError(f"Snapshot must contain {INDEX_NAME} at its root")

--- a/server/main.py
+++ b/server/main.py
@@ -4,12 +4,14 @@ FastAPI backend: site analysis, content distillation, app generation & download.
 """
 
 import asyncio
+import base64
 import hashlib
 import ipaddress
 import json
 import re
 import secrets
 import shutil
+import tempfile
 import threading
 import time
 import uuid
@@ -20,7 +22,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import httpx
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse, FileResponse, JSONResponse, RedirectResponse, PlainTextResponse
 from fastapi.middleware.cors import CORSMiddleware
@@ -28,6 +30,7 @@ from pydantic import BaseModel
 from typing import Dict, List, Optional
 
 from server import config
+from server import html_site
 from server.engine.analyzer import SiteAnalyzer
 from server.engine.distiller import Distiller
 from server.engine.recipe import RecipeStore
@@ -239,7 +242,11 @@ class DistillTaskQueue:
     async def submit(self, payload: dict) -> dict:
         now = _utc_now_iso()
         task_id = uuid.uuid4().hex
-        app_id = hashlib.md5(f"{payload['url']}:{payload.get('name', '')}".encode()).hexdigest()[:8]
+        # HTML uploads pass an explicit app_id (derived from content hash);
+        # URL flows keep deriving it from url:name.
+        app_id = payload.get("app_id") or hashlib.md5(
+            f"{payload['url']}:{payload.get('name', '')}".encode()
+        ).hexdigest()[:8]
         task = {
             "task_id": task_id,
             "app_id": app_id,
@@ -439,16 +446,23 @@ def _history_payload(request: Request) -> dict:
     return {"items": items}
 
 
-def _import_recipe_from_payload(item: dict) -> dict:
+def _import_recipe_from_payload(item: dict, base_url: str = "") -> dict:
     snapshot = deepcopy(item.get("snapshot") or {})
     recipe = deepcopy(item.get("recipe") or snapshot.get("recipe") or {})
     app_id = str(item.get("app_id") or snapshot.get("app_id") or recipe.get("id") or "").strip()
-    target_url = str(recipe.get("url") or snapshot.get("target_url") or "").strip()
+    source_type = recipe.get("source_type") or snapshot.get("source_type") or "url"
+    if source_type == "html":
+        # The stored URL embeds the exporting server's base URL; re-derive it
+        # from the importing server so artifacts point at the right host.
+        target_url = f"{str(base_url or '').rstrip('/')}/a/{app_id}/site/{html_site.INDEX_NAME}"
+    else:
+        target_url = str(recipe.get("url") or snapshot.get("target_url") or "").strip()
     if not app_id or not target_url:
         raise ValueError("invalid history item")
     normalized = {
         "id": app_id,
         "url": target_url,
+        "source_type": source_type,
         "name": recipe.get("name") or snapshot.get("name") or app_id,
         "color": recipe.get("color") or snapshot.get("color") or "#7c3aed",
         "display": recipe.get("display") or snapshot.get("display") or "fullscreen",
@@ -459,6 +473,8 @@ def _import_recipe_from_payload(item: dict) -> dict:
         "custom_icon_uploaded": bool(item.get("icon_data_url") or recipe.get("custom_icon_uploaded") or snapshot.get("custom_icon_uploaded")),
         "options": recipe.get("options") or {},
     }
+    if source_type == "html":
+        normalized["content_hash"] = recipe.get("content_hash") or snapshot.get("content_hash") or ""
     icon_data_url = str(item.get("icon_data_url") or "").strip()
     if icon_data_url:
         normalized["_custom_icon_data_url"] = icon_data_url
@@ -466,15 +482,28 @@ def _import_recipe_from_payload(item: dict) -> dict:
 
 
 def _build_distill_response(payload: dict, progress_cb=None) -> dict:
-    app_id = hashlib.md5(f"{payload['url']}:{payload.get('name', '')}".encode()).hexdigest()[:8]
+    source_type = payload.get("source_type") or "url"
+    app_id = payload.get("app_id") or hashlib.md5(
+        f"{payload['url']}:{payload.get('name', '')}".encode()
+    ).hexdigest()[:8]
+    if source_type == "html":
+        # The "site" is hosted by this server; the recipe URL points at the
+        # staged content so every platform artifact reuses the URL pipeline.
+        base_url = str(payload.get("base_url") or "").rstrip("/")
+        site_index = payload.get("site_index") or html_site.INDEX_NAME
+        target_url = f"{base_url}/a/{app_id}/site/{site_index}"
+    else:
+        target_url = str(payload["url"])
     recipe = distiller.create_recipe(
         app_id=app_id,
-        url=str(payload["url"]),
+        url=target_url,
         name=payload.get("name") or "",
         color=payload.get("color") or "#7c3aed",
         display=payload.get("display") or "fullscreen",
         orientation=payload.get("orientation") or "any",
         options=payload.get("options") or {},
+        source_type=source_type,
+        content_hash=payload.get("content_hash"),
     )
     app_dir = APPS_DIR / app_id
     base_url = payload.get("base_url") or ""
@@ -695,20 +724,25 @@ async def _startup_services():
     retention_task = asyncio.create_task(_retention_loop(), name="app-retention-sweeper")
 
 
+def _enforce_daily_quota(device_fingerprint: Optional[str]) -> None:
+    quota = config.daily_build_quota_per_device()
+    if quota <= 0 or not device_fingerprint:
+        return
+    since_iso = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    used = history_store.count_recent_builds(device_fingerprint, since_iso)
+    if used >= quota:
+        raise HTTPException(
+            status_code=429,
+            detail=f"已达每日生成上限（{used}/{quota}），24 小时后自动恢复。",
+        )
+
+
 @app.post("/api/distill")
 async def distill_app(req: DistillRequest, request: Request):
     if not await distill_rate_limiter.allow(_client_ip(request)):
         raise HTTPException(status_code=429, detail="提交太频繁，请稍后再试。")
     device_fingerprint = _device_fingerprint(request)
-    quota = config.daily_build_quota_per_device()
-    if quota > 0 and device_fingerprint:
-        since_iso = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
-        used = history_store.count_recent_builds(device_fingerprint, since_iso)
-        if used >= quota:
-            raise HTTPException(
-                status_code=429,
-                detail=f"已达每日生成上限（{used}/{quota}），24 小时后自动恢复。",
-            )
+    _enforce_daily_quota(device_fingerprint)
     task = await distill_queue.submit(
         {
             "url": str(req.url),
@@ -767,6 +801,122 @@ class UpdateUrlRequest(BaseModel):
     edit_token: Optional[str] = None
 
 
+# --- HTML-to-App uploads ---
+async def _read_upload_capped(file: UploadFile) -> bytes:
+    cap = config.html_upload_max_bytes()
+    data = await file.read(cap + 1)
+    if len(data) > cap:
+        raise HTTPException(
+            status_code=413,
+            detail={"code": "htmlUpload.tooLarge", "message": "Uploaded file is too large"},
+        )
+    if not data:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "htmlUpload.invalid", "message": "Uploaded file is empty"},
+        )
+    return data
+
+
+def _analyze_html_bytes(data: bytes, filename: str) -> dict:
+    """Local-only analysis of an uploaded HTML app: title, theme color and a
+    favicon preview. Stages into a throwaway temp dir; nothing persists."""
+    with tempfile.TemporaryDirectory() as tmp:
+        staged_dir = Path(tmp) / "site"
+        staged = html_site.validate_and_extract(data, filename, staged_dir)
+        meta = html_site.extract_site_meta(staged_dir)
+    icon_data_url = None
+    if meta.get("icon_png"):
+        icon_data_url = "data:image/png;base64," + base64.b64encode(meta["icon_png"]).decode("ascii")
+    return {
+        "sourceType": "html",
+        "name": meta.get("title") or "",
+        "color": meta.get("theme_color") or "",
+        "iconDataUrl": icon_data_url,
+        "fileCount": staged["file_count"],
+        "totalBytes": staged["total_bytes"],
+    }
+
+
+@app.post("/api/analyze/html")
+async def analyze_html_upload(request: Request, file: UploadFile = File(...)):
+    if not await distill_rate_limiter.allow(_client_ip(request)):
+        raise HTTPException(status_code=429, detail="提交太频繁，请稍后再试。")
+    data = await _read_upload_capped(file)
+    try:
+        result = await asyncio.to_thread(_analyze_html_bytes, data, file.filename)
+    except html_site.HtmlUploadError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "htmlUpload.invalid", "message": str(exc)},
+        )
+    log_event(
+        "analyze_html_done",
+        filename=str(file.filename or ""),
+        name=result.get("name"),
+        file_count=result.get("fileCount"),
+    )
+    return result
+
+
+@app.post("/api/distill/html")
+async def distill_html_app(
+    request: Request,
+    file: UploadFile = File(...),
+    name: str = Form(""),
+    color: str = Form("#7c3aed"),
+    display: str = Form("fullscreen"),
+    orientation: str = Form("any"),
+    options: str = Form(""),
+):
+    """Build an app from uploaded HTML content (single .html or .zip bundle).
+
+    Mirrors /api/distill: same rate limits and per-device daily quota, same
+    202 + task polling contract. The content is staged under
+    ``generated/<app_id>/site/`` before the task is enqueued."""
+    if not await distill_rate_limiter.allow(_client_ip(request)):
+        raise HTTPException(status_code=429, detail="提交太频繁，请稍后再试。")
+    device_fingerprint = _device_fingerprint(request)
+    _enforce_daily_quota(device_fingerprint)
+    try:
+        parsed_options = json.loads(options) if str(options).strip() else {}
+        if not isinstance(parsed_options, dict):
+            raise ValueError("options must be a JSON object")
+    except ValueError as exc:
+        raise HTTPException(422, "options must be a JSON object") from exc
+    data = await _read_upload_capped(file)
+    try:
+        staged = await asyncio.to_thread(html_site.stage_html_app, data, file.filename, name, APPS_DIR)
+    except html_site.HtmlUploadError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "htmlUpload.invalid", "message": str(exc)},
+        )
+    task = await distill_queue.submit(
+        {
+            "source_type": "html",
+            "app_id": staged["app_id"],
+            "content_hash": staged["content_hash"],
+            "site_index": staged["index_name"],
+            "name": staged["name"],
+            "color": color,
+            "display": display,
+            "orientation": orientation,
+            "options": parsed_options,
+            "base_url": _resolve_base_url(request),
+            "device_fingerprint": device_fingerprint,
+        }
+    )
+    log_event(
+        "distill_html_submitted",
+        task_id=task.get("task_id"),
+        app_id=task.get("app_id"),
+        filename=str(file.filename or ""),
+        client_ip=_client_ip(request),
+    )
+    return JSONResponse(task, status_code=202)
+
+
 @app.patch("/api/app/{app_id}/url")
 async def update_app_url(app_id: str, body: UpdateUrlRequest, request: Request):
     """Hot-swap the target URL of an already-installed Web Clip.
@@ -781,6 +931,11 @@ async def update_app_url(app_id: str, body: UpdateUrlRequest, request: Request):
     if not recipe_path.exists():
         raise HTTPException(404, "App not found")
     recipe = json.loads(recipe_path.read_text())
+
+    if recipe.get("source_type") == "html":
+        # HTML apps bundle their content on this server; repointing the URL
+        # would orphan the hosted site bundle.
+        raise HTTPException(409, "URL hot-swap is not supported for HTML apps; rebuild with new content instead")
 
     expected = str(recipe.get("edit_token") or "")
     supplied = str(body.edit_token or request.headers.get("x-edit-token", "") or "")
@@ -962,9 +1117,39 @@ async def recover_history(request: Request):
     return {"recovered": recovered, "history": _history_payload(request)}
 
 
+def _decode_site_files(item: dict):
+    """Decode the base64 site bundle embedded in an exported history item."""
+    raw_files = (item.get("site_files") or [])
+    files = []
+    for entry in raw_files:
+        try:
+            files.append({"name": str(entry.get("name") or ""), "data": base64.b64decode(entry.get("data") or "")})
+        except Exception:
+            return None
+    return files or None
+
+
 @app.get("/api/history/export")
 async def export_history(request: Request):
-    return history_store.export_history(_device_fingerprint(request), APPS_DIR)
+    payload = history_store.export_history(_device_fingerprint(request), APPS_DIR)
+    export_cap = config.html_export_max_bytes()
+    for item in payload.get("items") or []:
+        recipe = item.get("recipe") or {}
+        if recipe.get("source_type") != "html":
+            continue
+        site_dir = APPS_DIR / str(item.get("app_id") or "") / "site"
+        if not site_dir.is_dir():
+            item["site_files_skipped"] = True
+            continue
+        files = html_site.iter_site_files(site_dir)
+        total = sum(len(f["data"]) for f in files)
+        if total > export_cap:
+            item["site_files_skipped"] = True
+            continue
+        item["site_files"] = [
+            {"name": f["name"], "data": base64.b64encode(f["data"]).decode("ascii")} for f in files
+        ]
+    return payload
 
 
 @app.post("/api/history/import")
@@ -979,7 +1164,7 @@ async def import_history(payload: HistoryImportPayload, request: Request):
     errors = []
     for item in payload.items:
         try:
-            recipe = _import_recipe_from_payload(item)
+            recipe = _import_recipe_from_payload(item, base_url)
             app_id = recipe["id"]
             app_dir = APPS_DIR / app_id
             recipe_path = app_dir / "recipe.json"
@@ -996,6 +1181,11 @@ async def import_history(payload: HistoryImportPayload, request: Request):
                 except Exception:
                     effective_recipe = recipe
             if should_restore:
+                if recipe.get("source_type") == "html":
+                    site_files = _decode_site_files(item)
+                    if not site_files:
+                        raise ValueError("HTML app snapshot carries no site bundle (skipped at export or corrupt)")
+                    await asyncio.to_thread(html_site.restore_site_files, app_dir / "site", site_files)
                 distiller.write_app_files(app_dir, recipe, base_url=base_url)
                 effective_recipe = _load_recipe(app_id)
                 restored += 1
@@ -1164,6 +1354,29 @@ async def serve_manifest(app_id: str):
     if not manifest.exists():
         raise HTTPException(404)
     return FileResponse(manifest, media_type="application/manifest+json")
+
+
+@app.get("/a/{app_id}/site/{file_path:path}")
+@app.get("/a/{app_id}/site")
+async def serve_app_site(app_id: str, file_path: str = ""):
+    """Serve the hosted content of an HTML app.
+
+    Path traversal is contained by resolve_site_file (resolved paths must stay
+    inside ``generated/<app_id>/site``); directory requests fall back to
+    index.html. Each hit records a visit so the 30-day retention sweep keeps
+    actively-used apps alive."""
+    site_dir = APPS_DIR / app_id / "site"
+    if not site_dir.is_dir():
+        raise HTTPException(404, "Site not found")
+    path = html_site.resolve_site_file(site_dir, file_path)
+    if path is None:
+        raise HTTPException(404, "Site file not found")
+    history_store.record_visit(app_id, "site")
+    return FileResponse(
+        path,
+        media_type=html_site.mime_for(path),
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
 
 
 @app.get("/a/{app_id}/sw.js")

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.115.0
+python-multipart==0.0.9
 uvicorn[standard]==0.30.0
 httpx==0.27.0
 Pillow==10.4.0

--- a/tests/test_html_site.py
+++ b/tests/test_html_site.py
@@ -1,0 +1,472 @@
+"""Tests for the HTML-to-App feature: staging, validation, serving, endpoints."""
+
+import io
+import json
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from server import html_site
+from server.engine.distiller import Distiller
+
+
+def _zip_bytes(entries):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        for name, data in entries.items():
+            z.writestr(name, data)
+    return buf.getvalue()
+
+
+INDEX_HTML = b"""<!DOCTYPE html>
+<html><head>
+<title>My Html App</title>
+<meta name="theme-color" content="#123456">
+<link rel="apple-touch-icon" href="icon.png">
+</head><body><h1>Hello</h1></body></html>"""
+
+TINY_PNG = Distiller()._make_placeholder_png("#123456", 16)
+
+
+class ValidateAndExtractTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def test_single_html_file_staged_as_index(self):
+        dest = self.tmp / "site"
+        info = html_site.validate_and_extract(INDEX_HTML, "app.html", dest)
+        self.assertEqual((dest / "index.html").read_bytes(), INDEX_HTML)
+        self.assertEqual(info["index_name"], "index.html")
+        self.assertEqual(info["file_count"], 1)
+        self.assertEqual(info["total_bytes"], len(INDEX_HTML))
+        self.assertTrue(info["content_hash"])
+
+    def test_zip_with_single_root_flattens(self):
+        data = _zip_bytes({"mysite/index.html": INDEX_HTML, "mysite/app.js": b"console.log(1)"})
+        dest = self.tmp / "site"
+        info = html_site.validate_and_extract(data, "site.zip", dest)
+        self.assertEqual((dest / "index.html").read_bytes(), INDEX_HTML)
+        self.assertEqual((dest / "app.js").read_bytes(), b"console.log(1)")
+        self.assertEqual(info["file_count"], 2)
+
+    def test_zip_keeps_layout_with_root_files(self):
+        data = _zip_bytes({"index.html": INDEX_HTML, "img/logo.png": TINY_PNG})
+        dest = self.tmp / "site"
+        html_site.validate_and_extract(data, "site.zip", dest)
+        self.assertTrue((dest / "img" / "logo.png").is_file())
+
+    def test_zip_without_index_rejected(self):
+        data = _zip_bytes({"about.html": b"<p>x</p>"})
+        dest = self.tmp / "site"
+        with self.assertRaises(html_site.HtmlUploadError):
+            html_site.validate_and_extract(data, "site.zip", dest)
+        self.assertFalse(dest.exists())
+
+    def test_zip_slip_rejected(self):
+        data = _zip_bytes({"../evil.txt": b"boom", "index.html": INDEX_HTML})
+        dest = self.tmp / "site"
+        with self.assertRaises(html_site.HtmlUploadError):
+            html_site.validate_and_extract(data, "site.zip", dest)
+        self.assertFalse((self.tmp / "evil.txt").exists())
+
+    def test_absolute_path_entry_rejected(self):
+        data = _zip_bytes({"/etc/passwd": b"boom"})
+        with self.assertRaises(html_site.HtmlUploadError):
+            html_site.validate_and_extract(data, "site.zip", self.tmp / "site")
+
+    def test_file_count_cap(self):
+        entries = {f"f{i}.txt": b"x" for i in range(5)}
+        entries["index.html"] = INDEX_HTML
+        data = _zip_bytes(entries)
+        with patch.object(html_site.config, "html_site_max_file_count", return_value=3):
+            with self.assertRaises(html_site.HtmlUploadError):
+                html_site.validate_and_extract(data, "site.zip", self.tmp / "site")
+
+    def test_uncompressed_size_cap(self):
+        entries = {"index.html": INDEX_HTML, "big.bin": b"a" * (64 * 1024 + 1)}
+        data = _zip_bytes(entries)
+        with patch.object(html_site.config, "html_site_max_uncompressed_bytes", return_value=64 * 1024):
+            with self.assertRaises(html_site.HtmlUploadError):
+                html_site.validate_and_extract(data, "site.zip", self.tmp / "site")
+
+    def test_junk_entries_filtered_anywhere(self):
+        data = _zip_bytes({
+            "index.html": INDEX_HTML,
+            "__MACOSX/junk": b"junk",
+            "nested/__MACOSX/junk": b"junk",
+            "nested/.DS_Store": b"junk",
+        })
+        dest = self.tmp / "site"
+        info = html_site.validate_and_extract(data, "site.zip", dest)
+        self.assertEqual(info["file_count"], 1)
+        self.assertFalse((dest / "__MACOSX").exists())
+        self.assertFalse((dest / "nested").exists())
+
+    def test_unsupported_extension_rejected(self):
+        with self.assertRaises(html_site.HtmlUploadError):
+            html_site.validate_and_extract(b"x", "app.exe", self.tmp / "site")
+
+    def test_empty_upload_rejected(self):
+        with self.assertRaises(html_site.HtmlUploadError):
+            html_site.validate_and_extract(b"", "app.html", self.tmp / "site")
+
+
+class AppIdAndStagingTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def test_app_id_stable_for_same_content_and_name(self):
+        first = html_site.app_id_for("hash123", "My App")
+        second = html_site.app_id_for("hash123", "My App")
+        self.assertEqual(first, second)
+        self.assertNotEqual(first, html_site.app_id_for("hash123", "Other"))
+        self.assertNotEqual(first, html_site.app_id_for("hash456", "My App"))
+
+    def test_stage_html_app_writes_under_apps_dir(self):
+        data = _zip_bytes({"index.html": INDEX_HTML})
+        info = html_site.stage_html_app(data, "site.zip", "My App", self.tmp)
+        site_dir = self.tmp / info["app_id"] / "site"
+        self.assertEqual(site_dir, info["site_dir"])
+        self.assertTrue((site_dir / "index.html").is_file())
+        # No staging leftovers.
+        self.assertEqual([p.name for p in self.tmp.iterdir() if p.name.startswith(".stage-")], [])
+
+    def test_stage_html_app_replaces_previous_site(self):
+        data = _zip_bytes({"index.html": INDEX_HTML})
+        info = html_site.stage_html_app(data, "site.zip", "My App", self.tmp)
+        site_dir = self.tmp / info["app_id"] / "site"
+        (site_dir / "old.txt").write_bytes(b"stale")
+        html_site.stage_html_app(data, "site.zip", "My App", self.tmp)
+        self.assertFalse((site_dir / "old.txt").exists())
+        self.assertTrue((site_dir / "index.html").is_file())
+
+    def test_stage_failure_leaves_nothing(self):
+        data = _zip_bytes({"nope.txt": b"x"})
+        with self.assertRaises(html_site.HtmlUploadError):
+            html_site.stage_html_app(data, "site.zip", "My App", self.tmp)
+        self.assertEqual(list(self.tmp.iterdir()), [])
+
+
+class ResolveAndMetaTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.site = self.tmp / "site"
+        html_site.restore_site_files(self.site, [
+            {"name": "index.html", "data": INDEX_HTML},
+            {"name": "icon.png", "data": TINY_PNG},
+            {"name": "sub/page.html", "data": b"<p>sub</p>"},
+            {"name": "sub/index.html", "data": b"<p>sub home</p>"},
+        ])
+
+    def test_resolve_index_and_files(self):
+        # resolve() follows symlinks (/var → /private/var on macOS), so compare
+        # against resolved expectations rather than literal joins.
+        self.assertEqual(html_site.resolve_site_file(self.site, ""), (self.site / "index.html").resolve())
+        self.assertEqual(html_site.resolve_site_file(self.site, "index.html"), (self.site / "index.html").resolve())
+        self.assertEqual(html_site.resolve_site_file(self.site, "icon.png"), (self.site / "icon.png").resolve())
+        self.assertEqual(html_site.resolve_site_file(self.site, "sub/page.html"), (self.site / "sub" / "page.html").resolve())
+
+    def test_resolve_directory_falls_back_to_index(self):
+        self.assertEqual(html_site.resolve_site_file(self.site, "sub"), (self.site / "sub").resolve() / "index.html")
+        self.assertIsNone(html_site.resolve_site_file(self.site, "sub/nested-missing/"))
+
+    def test_resolve_traversal_blocked(self):
+        # Paths that resolve back INSIDE the site dir are allowed (they name
+        # the same file); only real escapes are rejected.
+        self.assertEqual(html_site.resolve_site_file(self.site, "../site/icon.png"), (self.site / "icon.png").resolve())
+        self.assertIsNone(html_site.resolve_site_file(self.site, "../../etc/passwd"))
+        self.assertIsNone(html_site.resolve_site_file(self.site, "../outside.txt"))
+
+    def test_mime_types(self):
+        self.assertEqual(html_site.mime_for(Path("a.html")), "text/html; charset=utf-8")
+        self.assertEqual(html_site.mime_for(Path("a.js")), "text/javascript; charset=utf-8")
+        self.assertEqual(html_site.mime_for(Path("a.png")), "image/png")
+        self.assertEqual(html_site.mime_for(Path("a.xyz")), "application/octet-stream")
+
+    def test_extract_site_meta(self):
+        meta = html_site.extract_site_meta(self.site)
+        self.assertEqual(meta["title"], "My Html App")
+        self.assertEqual(meta["theme_color"], "#123456")
+        self.assertEqual(meta["icon_png"], TINY_PNG)
+
+    def test_extract_site_meta_data_url_icon(self):
+        site = self.tmp / "site2"
+        import base64
+
+        html = (
+            b'<html><head><title>T</title>'
+            + b'<link rel="icon" href="data:image/png;base64,'
+            + base64.b64encode(TINY_PNG)
+            + b'"></head></html>'
+        )
+        html_site.restore_site_files(site, [{"name": "index.html", "data": html}])
+        meta = html_site.extract_site_meta(site)
+        self.assertEqual(meta["icon_png"], TINY_PNG)
+
+    def test_extract_site_meta_ignores_corrupt_data_url_icon(self):
+        site = self.tmp / "site3"
+        html = b'<html><head><link rel="icon" href="data:image/png;base64,iVBORw0KGgo="></head></html>'
+        html_site.restore_site_files(site, [{"name": "index.html", "data": html}])
+        meta = html_site.extract_site_meta(site)
+        self.assertIsNone(meta["icon_png"])
+
+    def test_restore_rejects_unsafe_and_missing_index(self):
+        with self.assertRaises(html_site.HtmlUploadError):
+            html_site.restore_site_files(self.tmp / "bad1", [{"name": "../x.txt", "data": b"x"}])
+        with self.assertRaises(html_site.HtmlUploadError):
+            html_site.restore_site_files(self.tmp / "bad2", [{"name": "a.txt", "data": b"x"}])
+
+
+class DistillerHtmlModeTests(unittest.TestCase):
+    def test_create_recipe_html_fields(self):
+        distiller = Distiller()
+        recipe = distiller.create_recipe(
+            app_id="ab12cd34", url="https://self.test/a/ab12cd34/site/index.html",
+            name="App", color="#123456", display="fullscreen", orientation="any",
+            options={}, source_type="html", content_hash="c0ffee",
+        )
+        self.assertEqual(recipe["source_type"], "html")
+        self.assertEqual(recipe["content_hash"], "c0ffee")
+
+    def test_create_recipe_url_mode_has_no_content_hash(self):
+        distiller = Distiller()
+        recipe = distiller.create_recipe(
+            app_id="ab12cd34", url="https://example.com",
+            name="App", color="#123456", display="fullscreen", orientation="any", options={},
+        )
+        self.assertEqual(recipe["source_type"], "url")
+        self.assertNotIn("content_hash", recipe)
+
+    def test_fetch_icon_uses_local_site_icon_for_html(self):
+        distiller = Distiller()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            html_site.restore_site_files(root / "ab12cd34" / "site", [{"name": "index.html", "data": INDEX_HTML},
+                                                                      {"name": "icon.png", "data": TINY_PNG}])
+            with patch.object(distiller, "_generated_root", return_value=root):
+                recipe = {"id": "ab12cd34", "url": "https://x/", "color": "#123456", "source_type": "html"}
+                icon = distiller._fetch_icon(recipe)
+        self.assertEqual(icon, TINY_PNG)
+
+    def test_fetch_icon_falls_back_to_placeholder(self):
+        distiller = Distiller()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            html_site.restore_site_files(root / "ab12cd34" / "site", [{"name": "index.html", "data": b"<p>no icon</p>"}])
+            with patch.object(distiller, "_generated_root", return_value=root):
+                recipe = {"id": "ab12cd34", "url": "https://x/", "color": "#112233", "source_type": "html"}
+                icon = distiller._fetch_icon(recipe)
+        self.assertEqual(icon, distiller._make_placeholder_png("#112233"))
+
+    def test_download_page_marks_html_apps(self):
+        distiller = Distiller()
+        with tempfile.TemporaryDirectory() as tmp:
+            app_dir = Path(tmp) / "ab12cd34"
+            recipe = distiller.create_recipe(
+                app_id="ab12cd34", url="https://self.test/a/ab12cd34/site/index.html",
+                name="App", color="#123456", display="fullscreen", orientation="any",
+                options={}, source_type="html",
+            )
+            html = distiller.render_download_page(app_dir, recipe)
+        self.assertIn('data-i18n="openApp"', html)
+        self.assertIn("HTML App", html)
+        # URL-mode pages keep the original label.
+        url_recipe = distiller.create_recipe(
+            app_id="ab12cd34", url="https://example.com",
+            name="App", color="#123456", display="fullscreen", orientation="any", options={},
+        )
+        url_html = distiller.render_download_page(app_dir, url_recipe)
+        self.assertIn('data-i18n="openSite"', url_html)
+
+
+class HtmlAppEndpointTests(unittest.TestCase):
+    def setUp(self):
+        from server import main
+
+        self.main = main
+        self.client = TestClient(main.app)
+        self.tmp = Path(tempfile.mkdtemp())
+        self._apps_dir = main.APPS_DIR
+        main.APPS_DIR = self.tmp
+        self._allow = main.distill_rate_limiter.allow
+        main.distill_rate_limiter.allow = AsyncMock(return_value=True)
+
+    def tearDown(self):
+        self.main.APPS_DIR = self._apps_dir
+        self.main.distill_rate_limiter.allow = self._allow
+
+    def test_analyze_html_endpoint(self):
+        resp = self.client.post(
+            "/api/analyze/html",
+            files={"file": ("app.html", INDEX_HTML, "text/html")},
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["sourceType"], "html")
+        self.assertEqual(body["name"], "My Html App")
+        self.assertEqual(body["color"], "#123456")
+        self.assertEqual(body["fileCount"], 1)
+        self.assertTrue(body["iconDataUrl"].startswith("data:image/png;base64,") if body["iconDataUrl"] else True)
+
+    def test_analyze_html_rejects_bad_zip(self):
+        resp = self.client.post(
+            "/api/analyze/html",
+            files={"file": ("app.zip", b"not a zip", "application/zip")},
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json()["detail"]["code"], "htmlUpload.invalid")
+
+    def test_distill_html_stages_and_submits(self):
+        submitted = {}
+
+        async def fake_submit(payload):
+            submitted.update(payload)
+            return {"task_id": "t1", "app_id": payload.get("app_id"), "status": "pending"}
+
+        data = _zip_bytes({"index.html": INDEX_HTML, "icon.png": TINY_PNG})
+        with patch.object(self.main.distill_queue, "submit", side_effect=fake_submit):
+            resp = self.client.post(
+                "/api/distill/html",
+                files={"file": ("site.zip", data, "application/zip")},
+                data={"name": "My App", "color": "#123456", "options": json.dumps({"feature-desktop-mode": True})},
+            )
+        self.assertEqual(resp.status_code, 202)
+        body = resp.json()
+        self.assertEqual(body["status"], "pending")
+        self.assertEqual(submitted["source_type"], "html")
+        self.assertEqual(submitted["name"], "My App")
+        self.assertEqual(submitted["options"], {"feature-desktop-mode": True})
+        site_dir = self.tmp / submitted["app_id"] / "site"
+        self.assertTrue((site_dir / "index.html").is_file())
+        self.assertTrue((site_dir / "icon.png").is_file())
+
+    def test_distill_html_rejects_oversized(self):
+        big = b"<html>" + b"x" * (64 * 1024 + 16)
+        with patch.object(self.main.config, "html_upload_max_bytes", return_value=64 * 1024):
+            resp = self.client.post(
+                "/api/distill/html",
+                files={"file": ("big.html", big, "text/html")},
+                data={},
+            )
+        self.assertEqual(resp.status_code, 413)
+        self.assertEqual(resp.json()["detail"]["code"], "htmlUpload.tooLarge")
+
+    def test_serve_app_site_routes(self):
+        app_id = "ff001122"
+        html_site.restore_site_files(self.tmp / app_id / "site", [
+            {"name": "index.html", "data": INDEX_HTML},
+            {"name": "app.js", "data": b"console.log(1);"},
+            {"name": "img/logo.png", "data": TINY_PNG},
+        ])
+        root = self.client.get(f"/a/{app_id}/site")
+        self.assertEqual(root.status_code, 200)
+        self.assertIn("text/html", root.headers["content-type"])
+        self.assertIn(b"My Html App", root.content)
+
+        js = self.client.get(f"/a/{app_id}/site/app.js")
+        self.assertEqual(js.status_code, 200)
+        self.assertIn("text/javascript", js.headers["content-type"])
+        self.assertIn("max-age=3600", js.headers.get("cache-control", ""))
+
+        png = self.client.get(f"/a/{app_id}/site/img/logo.png")
+        self.assertEqual(png.status_code, 200)
+        self.assertEqual(png.headers["content-type"], "image/png")
+
+        missing = self.client.get(f"/a/{app_id}/site/nope.css")
+        self.assertEqual(missing.status_code, 404)
+
+        unknown_app = self.client.get("/a/deadbeef/site/index.html")
+        self.assertEqual(unknown_app.status_code, 404)
+
+    def test_patch_url_rejected_for_html_apps(self):
+        app_id = "ab99cd88"
+        app_dir = self.tmp / app_id
+        app_dir.mkdir(parents=True)
+        (app_dir / "recipe.json").write_text(json.dumps({
+            "id": app_id, "url": "https://self.test/a/ab99cd88/site/index.html",
+            "source_type": "html", "edit_token": "tok",
+        }))
+        resp = self.client.patch(
+            f"/api/app/{app_id}/url",
+            json={"url": "https://evil.test", "edit_token": "tok"},
+        )
+        self.assertEqual(resp.status_code, 409)
+
+
+class BuildResponseAndImportTests(unittest.TestCase):
+    def test_build_distill_response_derives_html_url(self):
+        from server import main
+
+        payload = {
+            "source_type": "html",
+            "app_id": "ab12cd34",
+            "content_hash": "c0ffee",
+            "site_index": "index.html",
+            "name": "App",
+            "color": "#123456",
+            "display": "fullscreen",
+            "orientation": "any",
+            "options": {},
+            "base_url": "https://self.test",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            apps_dir = Path(tmp)
+            with patch.object(main, "APPS_DIR", apps_dir), \
+                 patch.object(main.distiller, "write_app_files", return_value={
+                     "ios": {}, "android": {}, "runtime_url": "", "platform_errors": {},
+                 }) as write_mock, \
+                 patch.object(main.history_store, "record_build") as record_mock:
+                result = main._build_distill_response(payload)
+        recipe = result["recipe"]
+        self.assertEqual(recipe["source_type"], "html")
+        self.assertEqual(recipe["content_hash"], "c0ffee")
+        self.assertEqual(recipe["url"], "https://self.test/a/ab12cd34/site/index.html")
+        write_mock.assert_called_once()
+        record_mock.assert_called_once()
+
+    def test_import_recipe_rederives_html_url(self):
+        from server import main
+
+        item = {
+            "app_id": "ab12cd34",
+            "recipe": {
+                "id": "ab12cd34",
+                "url": "https://old-server.test/a/ab12cd34/site/index.html",
+                "source_type": "html",
+                "content_hash": "c0ffee",
+                "name": "App",
+            },
+        }
+        recipe = main._import_recipe_from_payload(item, base_url="https://new-server.test")
+        self.assertEqual(recipe["url"], "https://new-server.test/a/ab12cd34/site/index.html")
+        self.assertEqual(recipe["source_type"], "html")
+        self.assertEqual(recipe["content_hash"], "c0ffee")
+
+    def test_import_recipe_url_mode_unchanged(self):
+        from server import main
+
+        item = {"app_id": "id1", "recipe": {"id": "id1", "url": "https://example.com", "name": "X"}}
+        recipe = main._import_recipe_from_payload(item, base_url="https://new-server.test")
+        self.assertEqual(recipe["url"], "https://example.com")
+        self.assertEqual(recipe["source_type"], "url")
+
+    def test_decode_site_files(self):
+        from server import main
+        import base64
+
+        item = {"site_files": [
+            {"name": "index.html", "data": base64.b64encode(INDEX_HTML).decode("ascii")},
+            {"name": "icon.png", "data": base64.b64encode(TINY_PNG).decode("ascii")},
+        ]}
+        files = main._decode_site_files(item)
+        self.assertEqual(files[0]["name"], "index.html")
+        self.assertEqual(files[0]["data"], INDEX_HTML)
+        self.assertIsNone(main._decode_site_files({}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #14

## Summary

在"网址转 App"之外新增第二种输入模式：上传单个 `.html` 文件或含 `index.html` 的 `.zip` 站点包。内容由服务器托管在 `generated/<app_id>/site/`（经 `/a/{id}/site/...` 提供），五个平台产物全部指向该 URL，**完整复用现有 URL 打包链路**——之所以选择服务器托管，是因为 iOS Web Clip 与桌面启动器本质上只能打开 URL，托管方案是唯一能让五端走同一条代码路径的架构。

- `server/html_site.py`（新）：暂存与校验（zip-slip、zip 炸弹压缩比、条目数/解压大小上限、`__MACOSX`/`.DS_Store` 垃圾过滤）；content_hash → 稳定 app_id（同内容+同名重建 = version_code 自增、keystore/edit_token 复用）；站点文件解析含路径穿越防护；本地 favicon 提取（analyze 与 distiller 共用，含魔数校验）
- `main.py`：`POST /api/distill/html`（multipart，与 URL 模式相同的 202/轮询契约、IP 限流与每日设备配额）、`POST /api/analyze/html`（纯本地解析 title/theme-color/favicon 预填）、`GET /a/{id}/site/{path}`（MIME、Cache-Control 1h、record_visit 续期 30 天保留）、`PATCH /api/app/{id}/url` 对 HTML 应用返回 409、历史导出内嵌 `site_files`（超限打标跳过）、导入还原文件并按导入方 base_url 重推导 recipe.url
- `distiller.py`：recipe 增加 `source_type`/`content_hash`；HTML 应用图标走 自定义 > HTML 声明 favicon > 纯色占位，全程无网络；下载页标签换为 "Open app"（九语言）
- 前端：输入区 网址/HTML 模式切换（含拖放）、analyze 预填、历史 HTML 徽标、九语言文案、缓存版本 bump
- 依赖：新增 `python-multipart`（FastAPI 表单上传必需）
- 配置：`HTML_UPLOAD_MAX_BYTES` / `HTML_SITE_MAX_UNCOMPRESSED_BYTES` / `HTML_SITE_MAX_FILE_COUNT` / `HTML_EXPORT_MAX_BYTES`（均有默认值，见 `.env.example`）

## Test plan

- [x] 新增 `tests/test_html_site.py` 38 个用例：校验矩阵（zip-slip/绝对路径/条目数/解压上限/缺 index/垃圾过滤）、app_id 稳定性、托管路由（MIME/目录回退/穿越 404）、PATCH 409、`_build_distill_response` URL 推导、导入 base_url 重推导、图标三级回退
- [x] 全量 `pytest tests/`：202 passed（原 164 + 新 38）
- [x] 端到端冒烟（本机 uvicorn）：上传 zip → 轮询 → 五端产物生成；站点路由 MIME/缓存头正确；`..` 穿越 404；`/launch` 302 到托管站点；下载页显示 HTML App；同内容重建 version_code 1→2；导出→删目录→导入完整还原且 URL 重推导
- [ ] CI：Python 3.10 / 3.11 / 3.12 矩阵