### PR TITLE
fix(android): make <input type=file> work in generated WebView APKs

### DIFF
--- a/server/engine/apk_builder.py
+++ b/server/engine/apk_builder.py
@@ -35,6 +35,7 @@ package w;
 import android.Manifest;
 import android.app.Activity;
 import android.app.DownloadManager;
+import android.content.ClipData;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -49,6 +50,7 @@ import android.webkit.DownloadListener;
 import android.webkit.GeolocationPermissions;
 import android.webkit.PermissionRequest;
 import android.webkit.URLUtil;
+import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
@@ -69,6 +71,7 @@ public class M extends Activity {
     private static final int REQ_WRITE_STORAGE = 2001;
     private static final int REQ_LOCATION = 2002;
     private static final int REQ_MEDIA = 2003;
+    private static final int REQ_FILE_CHOOSER = 2004;
     private static final String DESKTOP_USER_AGENT =
         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
         + "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
@@ -117,6 +120,7 @@ public class M extends Activity {
     private GeolocationPermissions.Callback pendingGeolocationCallback;
     private String pendingGeolocationOrigin;
     private PermissionRequest pendingPermissionRequest;
+    private ValueCallback<Uri[]> pendingFileChoiceCallback;
 
     /**
      * Returns true if the given host matches any blocked ad/tracker domain.
@@ -438,6 +442,34 @@ public class M extends Activity {
             return !isUserGesture;
         }
         // ─────────────────────────────────────────────────────────────────
+
+        // ── File chooser (<input type="file">) ────────────────────────────
+        // WebView ships no default file picker: without this override every
+        // tap on an <input type="file"> silently does nothing. We hand the
+        // request to the system picker via startActivityForResult and deliver
+        // the result back in onActivityResult.
+        @Override public boolean onShowFileChooser(WebView view, ValueCallback<Uri[]> callback,
+                                                   FileChooserParams params) {
+            // Settle any chooser still pending (e.g. the user backed out of a
+            // previous one without cancelling cleanly). Leaving it hanging
+            // makes WebView drop all future file-input taps.
+            if (pendingFileChoiceCallback != null) {
+                pendingFileChoiceCallback.onReceiveValue(null);
+            }
+            pendingFileChoiceCallback = callback;
+            try {
+                Intent intent = params.createIntent();
+                if (params.getMode() == FileChooserParams.MODE_OPEN_MULTIPLE) {
+                    intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+                }
+                startActivityForResult(intent, REQ_FILE_CHOOSER);
+                return true;
+            } catch (Throwable ignored) {
+                pendingFileChoiceCallback = null;
+                return false;
+            }
+        }
+        // ─────────────────────────────────────────────────────────────────
     }
 
     private final class AppDownloadListener implements DownloadListener {
@@ -552,6 +584,37 @@ public class M extends Activity {
         return true;
     }
 
+    @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode != REQ_FILE_CHOOSER) return;
+        ValueCallback<Uri[]> callback = pendingFileChoiceCallback;
+        pendingFileChoiceCallback = null;
+        if (callback == null) return;  // activity recreated meanwhile: WebView's callback is gone
+        // Deliver even when the user cancelled (null result) — leaving the
+        // callback hanging makes WebView ignore all later file-input taps.
+        callback.onReceiveValue(parseFileChooserResult(resultCode, data));
+    }
+
+    /**
+     * Converts the system picker result into the Uri[] the WebView expects.
+     * FileChooserParams.parseResult() only handles single selection, so
+     * multi-select results are read from ClipData here.
+     */
+    private Uri[] parseFileChooserResult(int resultCode, Intent data) {
+        if (resultCode != RESULT_OK || data == null) return null;
+        ClipData clip = data.getClipData();
+        if (clip != null) {
+            ArrayList<Uri> uris = new ArrayList<Uri>();
+            for (int i = 0; i < clip.getItemCount(); i++) {
+                Uri uri = clip.getItemAt(i).getUri();
+                if (uri != null) uris.add(uri);
+            }
+            return uris.isEmpty() ? null : uris.toArray(new Uri[0]);
+        }
+        Uri single = data.getData();
+        return single != null ? new Uri[]{single} : null;
+    }
+
     @Override public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         if (requestCode == REQ_WRITE_STORAGE) {
@@ -597,6 +660,7 @@ public class M extends Activity {
         pendingGeolocationCallback = null;
         pendingGeolocationOrigin = null;
         pendingPermissionRequest = null;
+        pendingFileChoiceCallback = null;
         if (webView != null) {
             webView.destroy();
             webView = null;
@@ -652,7 +716,7 @@ class ApkBuilder:
     TEMPLATE_APP_NAME = "WebToApp Template"
     TEMPLATE_VERSION_CODE = 1
     TEMPLATE_VERSION_NAME = "1.0"
-    TEMPLATE_REVISION = "2026-06-03-adblock-1"
+    TEMPLATE_REVISION = "2026-08-21-filechooser-1"
     # Keystore used only to sign the throwaway base *template* APK. The template
     # is always re-signed per-app afterwards, so this key never reaches users.
     TEMPLATE_KEY_ALIAS = "webtoapp"

--- a/tests/test_apk_template.py
+++ b/tests/test_apk_template.py
@@ -1,0 +1,48 @@
+"""Guards for the embedded WebView Activity source in apk_builder.
+
+The Java template ships as a string (ACTIVITY_JAVA) and is compiled on the
+build host, far away from CI — so these tests assert the load-bearing pieces
+of the source stay intact rather than executing anything.
+"""
+
+from server.engine.apk_builder import ACTIVITY_JAVA, ApkBuilder
+
+
+def test_activity_java_braces_balanced():
+    # Catches truncated / badly merged template edits before they reach the
+    # build host and fail there with a cryptic javac error.
+    assert ACTIVITY_JAVA.count("{") == ACTIVITY_JAVA.count("}")
+
+
+def test_file_chooser_is_wired_end_to_end():
+    # Issue #16: <input type="file"> did nothing because AppChromeClient never
+    # overrode onShowFileChooser (WebView has no default picker).
+    assert "@Override public boolean onShowFileChooser(" in ACTIVITY_JAVA
+    assert "startActivityForResult(intent, REQ_FILE_CHOOSER)" in ACTIVITY_JAVA
+    assert "protected void onActivityResult" in ACTIVITY_JAVA
+    assert "if (requestCode != REQ_FILE_CHOOSER) return;" in ACTIVITY_JAVA
+    assert "callback.onReceiveValue(parseFileChooserResult(resultCode, data))" in ACTIVITY_JAVA
+    assert "private Uri[] parseFileChooserResult(int resultCode, Intent data)" in ACTIVITY_JAVA
+
+
+def test_file_chooser_callback_always_settled():
+    # A callback that is never answered makes WebView silently drop every
+    # later <input type="file"> tap, so both the stale-chooser path and the
+    # cancel path must deliver null.
+    assert ACTIVITY_JAVA.count("pendingFileChoiceCallback.onReceiveValue(null)") == 1
+    assert "callback.onReceiveValue(parseFileChooserResult(resultCode, data))" in ACTIVITY_JAVA
+
+
+def test_file_chooser_imports_present():
+    assert "import android.content.ClipData;" in ACTIVITY_JAVA
+    assert "import android.webkit.ValueCallback;" in ACTIVITY_JAVA
+
+
+def test_template_revision_is_bumped_slug():
+    # Any change to ACTIVITY_JAVA must come with a new TEMPLATE_REVISION or
+    # build hosts keep serving the cached (stale) template APK.
+    revision = ApkBuilder.TEMPLATE_REVISION
+    parts = revision.split("-")
+    assert len(parts) >= 4
+    assert all(part.isdigit() for part in parts[:3])  # YYYY-MM-DD prefix
+    assert parts[3]  # feature slug


### PR DESCRIPTION
## Summary

Generated Android APKs silently ignored every tap on `<input type="file">` because the embedded WebView Activity's `WebChromeClient` never implemented `onShowFileChooser` — WebView ships no default file picker. This PR adds full file-chooser support to the APK template:

- `AppChromeClient.onShowFileChooser` hands off to the system picker via `startActivityForResult`, enabling multi-select for `MODE_OPEN_MULTIPLE`.
- `onActivityResult` + `parseFileChooserResult` deliver the picked `Uri[]` back to WebView, reading both single results and `ClipData` multi-select (`FileChooserParams.parseResult` only handles single).
- The callback is **always** settled — `null` on cancel, and stale pending callbacks are settled before opening a new picker — otherwise WebView treats the previous chooser as still open and silently drops all later file-input taps.
- `TEMPLATE_REVISION` bumped (`2026-08-21-filechooser-1`) so build hosts rebuild their cached template APK with the new Activity source.

## Fixes

Fixes #16

## Test plan

- [x] `pytest tests/` — 207 passed (Python 3.12 local; CI covers 3.10/3.11/3.12), including new `tests/test_apk_template.py` regression guards (chooser wiring, always-settled callback, imports, revision slug).
- [x] Template Java source compiles: extracted `ACTIVITY_JAVA` and ran the builder's own `javac -source 1.8 -bootclasspath android.jar` invocation — clean.
- [x] **End-to-end on a real emulator (Pixel_6, API 35):** built a 28 KB APK with the project's own `ApkBuilder`, installed it, and drove a test page with `<input type="file" multiple>`:
  - tapping the input opens the system Documents UI picker;
  - selecting a file delivers it back to the page (JS `onchange` fired, page showed `PICKED: upload-sample.txt`);
  - cancelling with BACK then re-tapping reopens the picker (no dead-tap regression).

## Notes for review

- `minSdkVersion` is 21 and `onShowFileChooser` is API 21+, so no legacy `openFileChooser` overload is needed.
- **Deploy note:** after merge, delete the cached `server/engine/_android_template/android-template.apk` and `template.revision` on the server before restarting, or existing hosts keep building from the stale template (the revision bump makes fresh checkouts rebuild automatically). Existing already-installed apps need a rebuild to pick this up.
- iOS / desktop artifacts are unaffected (their file pickers are the system browser's own).