### PR TITLE
fix(security): close duplicate-slash bypass of the sensitive-path blocklist

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -54,7 +54,28 @@ _LONG_CACHE_SUFFIXES = (".css", ".js", ".png", ".jpg", ".jpeg", ".webp", ".svg",
 # ``/generated`` holds per-app recipe.json files (which carry the secret
 # edit_token); they must only be reached via the curated /a/{id}/... routes.
 _BLOCKED_STATIC_PREFIXES = ("/certs", "/server", "/.git", "/deploy", "/generated")
-_BLOCKED_STATIC_SUFFIXES = (".keystore", ".jks", ".pem", ".key", ".p12", ".pfx")
+# ``.env`` covers the deployed webtoapp.env (R2 credentials); ``.json`` is
+# deliberately NOT listed — /a/{id}/manifest.json is a legitimate route, and
+# sensitive .json files all live under blocked prefixes anyway.
+_BLOCKED_STATIC_SUFFIXES = (".keystore", ".jks", ".pem", ".key", ".p12", ".pfx", ".env", ".bak", ".sqlite3", ".log")
+
+
+def _normalize_request_path(raw_path: str) -> str:
+    """Collapse duplicate slashes, strip trailing ones, lower-case.
+
+    StaticFiles resolves '//server/x' on disk just like '/server/x', so the
+    blocklist must judge the same normalized form — matching the raw string
+    let doubled slashes evade every prefix rule (issue #18).
+    """
+    return re.sub(r"/{2,}", "/", str(raw_path or "").rstrip("/")).lower()
+
+
+def _is_sensitive_path(raw_path: str) -> bool:
+    normalized = _normalize_request_path(raw_path)
+    return (
+        any(normalized == p or normalized.startswith(p + "/") for p in _BLOCKED_STATIC_PREFIXES)
+        or normalized.endswith(_BLOCKED_STATIC_SUFFIXES)
+    )
 
 
 @app.middleware("http")
@@ -69,13 +90,7 @@ async def block_sensitive_paths(request: Request, call_next):
     middleware runs outside Starlette's ExceptionMiddleware, so a raised
     HTTPException here would surface as a 500 instead of a 404.
     """
-    raw_path = request.url.path
-    normalized = raw_path.rstrip("/").lower()
-    blocked = (
-        any(normalized == p or normalized.startswith(p + "/") for p in _BLOCKED_STATIC_PREFIXES)
-        or normalized.endswith(_BLOCKED_STATIC_SUFFIXES)
-    )
-    if blocked:
+    if _is_sensitive_path(request.url.path):
         return PlainTextResponse("Not found", status_code=404)
     return await call_next(request)
 

--- a/tests/test_static_blocklist.py
+++ b/tests/test_static_blocklist.py
@@ -1,0 +1,109 @@
+"""Regression guards for the sensitive-path blocklist (issue #18).
+
+StaticFiles resolves '//server/x' on disk just like '/server/x', so the
+blocklist must judge a normalized path — matching the raw string let doubled
+slashes evade every prefix rule and serve recipe.json (edit tokens), keystore
+password manifests and server source.
+"""
+
+import asyncio
+import unittest
+
+from server import main
+
+
+class NormalizeRequestPathTests(unittest.TestCase):
+    def test_collapses_duplicate_and_trailing_slashes(self):
+        self.assertEqual(main._normalize_request_path("//server//main.py"), "/server/main.py")
+        self.assertEqual(main._normalize_request_path("///generated/abc/"), "/generated/abc")
+        self.assertEqual(main._normalize_request_path("/Index.HTML"), "/index.html")
+        self.assertEqual(main._normalize_request_path(""), "")
+        self.assertEqual(main._normalize_request_path(None), "")
+
+
+class SensitivePathTests(unittest.TestCase):
+    def test_prefix_rules_survive_doubled_slashes(self):
+        for path in (
+            "/server/main.py",
+            "//server/main.py",
+            "///server/config.py",
+            "//certs/app-keys/abc.json",
+            "//.git/HEAD",
+            "/generated/abc/recipe.json",
+            "//generated/_tasks.sqlite3",
+        ):
+            with self.subTest(path=path):
+                assert main._is_sensitive_path(path)
+
+    def test_suffix_rules(self):
+        for path in (
+            "/webtoapp.env",
+            "/deep/nested/backup.bak",
+            "/data.sqlite3",
+            "/debug.log",
+            "//certs/android-template.keystore",
+        ):
+            with self.subTest(path=path):
+                assert main._is_sensitive_path(path)
+
+    def test_legitimate_paths_still_pass(self):
+        for path in (
+            "/",
+            "/index.html",
+            "/css/style.css",
+            "/js/app.v5.js",
+            "/assets/screenshot-1.png",
+            "/a/abc123/manifest.json",  # legit route ending in .json
+            "/healthz",
+        ):
+            with self.subTest(path=path):
+                assert not main._is_sensitive_path(path)
+
+
+class MiddlewareWiringTests(unittest.TestCase):
+    """End-to-end through the ASGI app, so a future refactor cannot silently
+    unwire the blocklist from the middleware stack."""
+
+    @staticmethod
+    def _status_for(path: str) -> int:
+        async def call() -> int:
+            status = {"code": None}
+
+            async def receive():
+                return {"type": "http.request"}
+
+            async def send(message):
+                if message["type"] == "http.response.start":
+                    status["code"] = message["status"]
+
+            scope = {
+                "type": "http",
+                "asgi": {"version": "3.0", "spec_version": "2.3"},
+                "http_version": "1.1",
+                "method": "GET",
+                "scheme": "http",
+                "path": path,
+                "raw_path": path.encode(),
+                "query_string": b"",
+                "headers": [(b"host", b"testserver")],
+                "client": ("127.0.0.1", 12345),
+                "server": ("testserver", 80),
+            }
+            await main.app(scope, receive, send)
+            return status["code"] or 0
+
+        return asyncio.run(call())
+
+    def test_doubled_slash_sensitive_path_is_hard_404(self):
+        self.assertEqual(self._status_for("//server/main.py"), 404)
+        self.assertEqual(self._status_for("//generated/abc/recipe.json"), 404)
+
+    def test_plain_sensitive_path_is_hard_404(self):
+        self.assertEqual(self._status_for("/webtoapp.env"), 404)
+
+    def test_homepage_still_serves(self):
+        self.assertEqual(self._status_for("/index.html"), 200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The `block_sensitive_paths` middleware matched the raw request path, but `StaticFiles` resolves `//server/x` on disk exactly like `/server/x`. A doubled leading slash therefore evaded every prefix rule and the catch-all mount served:

- `generated/<id>/recipe.json` — every app's secret `edit_token`, enabling `PATCH /api/app/{id}/url` hijacks of installed Web Clips
- `certs/app-keys/<id>.json` — per-app keystore passwords (342 apps on the live host)
- `generated/_tasks.sqlite3` — task DB containing historical tokens
- `server/*.py` source

Verified exploitable against the live origin, including via direct-IP access that bypasses Cloudflare. Fix:

- `_normalize_request_path()` collapses runs of `/` (and strips trailing `/`, lower-cases) before any check; `_is_sensitive_path()` extracted as a pure predicate.
- Suffix blocklist extended with `.env` / `.bak` / `.sqlite3` / `.log`. `.json` is deliberately **not** added: `/a/{id}/manifest.json` is a legitimate route, and every sensitive `.json` lives under an already-blocked prefix.

## Fixes

Fixes #18

## Test plan

- [x] New `tests/test_static_blocklist.py`: normalization unit tests, prefix/suffix rules incl. doubled/tripled slashes, legitimate-path passthrough (`/a/x/manifest.json` must keep working), and end-to-end ASGI wiring tests. Full suite: 214 passed.
- [x] Manual probe matrix re-run locally against a dev server: all bypass paths now 404; `/`, `/css/*`, `/js/*` still 200.

## Notes for review

- Deployment also deletes stale `index.html.bak.*` from the deploy directory (ops step, done alongside sync).
- Post-deploy, access logs should be checked for historical `//generated` / `//certs` hits to assess whether tokens need rotation.