### PR TITLE
feat(security): gate /api/metrics behind token or loopback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,9 @@ HTML_SITE_MAX_FILE_COUNT=500
 # Max total site size embedded in an exported history snapshot (larger sites
 # are skipped from the export and flagged instead).
 HTML_EXPORT_MAX_BYTES=2097152
+
+# ---------- Ops ----------
+# Shared secret for GET /api/metrics (Authorization: Bearer <token> or
+# X-Metrics-Token). When unset, /api/metrics is restricted to loopback
+# callers instead of being publicly readable.
+METRICS_TOKEN=

--- a/server/config.py
+++ b/server/config.py
@@ -177,6 +177,17 @@ def trusted_proxy_cidrs() -> list[str]:
     return values or ["127.0.0.1/32", "::1/128"]
 
 
+def metrics_token() -> str:
+    """Shared secret for GET /api/metrics.
+
+    When set, callers must present it via ``Authorization: Bearer <token>``
+    or ``X-Metrics-Token``. When unset, the endpoint falls back to allowing
+    only loopback callers instead of being publicly readable (it discloses
+    filesystem paths, queue depths and keystore stats).
+    """
+    return os.environ.get("METRICS_TOKEN", "").strip()
+
+
 # ---------- HTML-to-App uploads ----------
 #
 # Uploaded HTML content (.html single file or .zip site bundle) is hosted by

--- a/server/main.py
+++ b/server/main.py
@@ -1042,7 +1042,21 @@ async def readyz():
 
 
 @app.get("/api/metrics")
-async def metrics():
+async def metrics(request: Request):
+    """Ops metrics. Not public: gated by METRICS_TOKEN when configured,
+    otherwise restricted to loopback callers (ops curl on the host itself).
+    The response discloses filesystem paths, queue depths and keystore
+    stats — fine for the operator, nothing a stranger needs."""
+    token = config.metrics_token()
+    if token:
+        supplied = (
+            request.headers.get("x-metrics-token", "").strip()
+            or request.headers.get("authorization", "").removeprefix("Bearer ").strip()
+        )
+        if not supplied or not secrets.compare_digest(supplied, token):
+            raise HTTPException(403, "Forbidden")
+    elif _client_ip(request) not in ("127.0.0.1", "::1"):
+        raise HTTPException(403, "Forbidden")
     apk_builder_ready = False
     try:
         from server.engine.apk_builder import ApkBuilder

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,4 +1,6 @@
+import os
 import unittest
+from unittest import mock
 
 from fastapi.testclient import TestClient
 
@@ -21,8 +23,7 @@ class HealthEndpointTests(unittest.TestCase):
         self.assertTrue(body.get("ok"))
         self.assertTrue(body.get("apps_writable"))
 
-    def test_metrics(self):
-        resp = self.client.get("/api/metrics")
+    def assert_metrics_body(self, resp):
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
         self.assertIn("distill", body)
@@ -32,6 +33,34 @@ class HealthEndpointTests(unittest.TestCase):
         self.assertIn("history", body)
         self.assertIn("android_builds", body)
         self.assertIn("keystores", body)
+
+    def test_metrics_forbidden_for_public_callers_without_token(self):
+        # TestClient's source host is "testclient" — i.e. not loopback — so
+        # with no METRICS_TOKEN configured the endpoint must refuse.
+        with mock.patch.dict(os.environ, {"METRICS_TOKEN": ""}):
+            resp = self.client.get("/api/metrics")
+        self.assertEqual(resp.status_code, 403)
+
+    def test_metrics_allowed_for_loopback_without_token(self):
+        with mock.patch.dict(os.environ, {"METRICS_TOKEN": ""}), \
+                mock.patch.object(main, "_client_ip", return_value="127.0.0.1"):
+            self.assert_metrics_body(self.client.get("/api/metrics"))
+
+    def test_metrics_accepts_bearer_and_header_token(self):
+        with mock.patch.dict(os.environ, {"METRICS_TOKEN": "s3cret"}):
+            self.assert_metrics_body(
+                self.client.get("/api/metrics", headers={"Authorization": "Bearer s3cret"})
+            )
+            self.assert_metrics_body(
+                self.client.get("/api/metrics", headers={"X-Metrics-Token": "s3cret"})
+            )
+
+    def test_metrics_rejects_wrong_token(self):
+        with mock.patch.dict(os.environ, {"METRICS_TOKEN": "s3cret"}):
+            resp = self.client.get("/api/metrics", headers={"Authorization": "Bearer nope"})
+            self.assertEqual(resp.status_code, 403)
+            resp = self.client.get("/api/metrics")
+            self.assertEqual(resp.status_code, 403)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`GET /api/metrics` was fully public and disclosed internals (filesystem paths via `keystores.dir`, queue depths, cache stats, keystore counts, feature flags). This PR gates it:

- **`METRICS_TOKEN` set** → callers must present it (`Authorization: Bearer <token>` or `X-Metrics-Token`), constant-time compared.
- **Unset** → restricted to loopback callers, so ops `curl` on the host still works while the public internet gets a hard 403. In production behind nginx, client IPs resolve through the trusted-proxy XFF path, so external callers are correctly identified as non-loopback.

`/healthz` and `/readyz` remain public (load-balancer probes). New env var documented in `.env.example`.

## Fixes

Fixes #21

## Test plan

- [x] `tests/test_health.py` rewritten to cover all four outcomes: public+no-token → 403, loopback+no-token → 200, valid Bearer / X-Metrics-Token → 200, wrong/missing token with token configured → 403.
- [x] Full suite: 217 passed.
- [ ] Post-deploy: verify `https://shiaho.sbs/api/metrics` → 403 from outside, 200 via localhost curl on the host.

## Notes for review

- No frontend code calls this endpoint (verified by grep), so gating cannot break the UI.