### PR TITLE
feat(security): isolate uploaded HTML apps from the API origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,3 +83,9 @@ HTML_EXPORT_MAX_BYTES=2097152
 # X-Metrics-Token). When unset, /api/metrics is restricted to loopback
 # callers instead of being publicly readable.
 METRICS_TOKEN=
+# Public origin that serves uploaded HTML-app content (/a/<id>/site/), e.g.
+# https://s.example.com (proxied to the same backend). When set, uploaded
+# pages execute on this isolated host and the main origin 301-redirects
+# /a/<id>/site/ there, so hostile uploaded JS cannot call the API with
+# visitor cookies. Empty = serve from the main origin (legacy behaviour).
+SITE_PUBLIC_BASE_URL=

--- a/server/config.py
+++ b/server/config.py
@@ -219,6 +219,18 @@ def html_site_max_file_count() -> int:
         return 500
 
 
+def site_public_base_url() -> str:
+    """Public origin that serves uploaded HTML-app content (/a/<id>/site/).
+
+    When set, uploaded pages execute on this isolated host instead of the API
+    origin: their JS then cannot invoke the API with the visitor's cookies
+    attached (cross-site -> SameSite=Lax cookies are not sent), closing the
+    same-origin hole in issue #20. The main origin 301-redirects /a/<id>/site/
+    requests here. Empty = serve from the main origin (legacy behaviour).
+    """
+    return os.environ.get("SITE_PUBLIC_BASE_URL", "").strip().rstrip("/")
+
+
 def html_export_max_bytes() -> int:
     """Maximum total site size embedded in an exported history snapshot.
     Larger sites are skipped from the export and flagged instead. Default 2 MB."""

--- a/server/main.py
+++ b/server/main.py
@@ -461,6 +461,16 @@ def _history_payload(request: Request) -> dict:
     return {"items": items}
 
 
+def _html_site_public_base(base_url: str) -> str:
+    """Origin that uploaded-site content should live on.
+
+    SITE_PUBLIC_BASE_URL wins over the request-derived origin when configured,
+    so uploaded pages execute on an isolated host instead of the API origin
+    (issue #20). Empty config keeps the legacy main-origin behaviour.
+    """
+    return config.site_public_base_url() or str(base_url or "").rstrip("/")
+
+
 def _import_recipe_from_payload(item: dict, base_url: str = "") -> dict:
     snapshot = deepcopy(item.get("snapshot") or {})
     recipe = deepcopy(item.get("recipe") or snapshot.get("recipe") or {})
@@ -469,7 +479,7 @@ def _import_recipe_from_payload(item: dict, base_url: str = "") -> dict:
     if source_type == "html":
         # The stored URL embeds the exporting server's base URL; re-derive it
         # from the importing server so artifacts point at the right host.
-        target_url = f"{str(base_url or '').rstrip('/')}/a/{app_id}/site/{html_site.INDEX_NAME}"
+        target_url = f"{_html_site_public_base(base_url)}/a/{app_id}/site/{html_site.INDEX_NAME}"
     else:
         target_url = str(recipe.get("url") or snapshot.get("target_url") or "").strip()
     if not app_id or not target_url:
@@ -504,7 +514,7 @@ def _build_distill_response(payload: dict, progress_cb=None) -> dict:
     if source_type == "html":
         # The "site" is hosted by this server; the recipe URL points at the
         # staged content so every platform artifact reuses the URL pipeline.
-        base_url = str(payload.get("base_url") or "").rstrip("/")
+        base_url = _html_site_public_base(payload.get("base_url"))
         site_index = payload.get("site_index") or html_site.INDEX_NAME
         target_url = f"{base_url}/a/{app_id}/site/{site_index}"
     else:
@@ -1387,13 +1397,28 @@ async def serve_manifest(app_id: str):
 
 @app.get("/a/{app_id}/site/{file_path:path}")
 @app.get("/a/{app_id}/site")
-async def serve_app_site(app_id: str, file_path: str = ""):
+async def serve_app_site(app_id: str, request: Request, file_path: str = ""):
     """Serve the hosted content of an HTML app.
 
     Path traversal is contained by resolve_site_file (resolved paths must stay
     inside ``generated/<app_id>/site``); directory requests fall back to
     index.html. Each hit records a visit so the 30-day retention sweep keeps
-    actively-used apps alive."""
+    actively-used apps alive.
+
+    When SITE_PUBLIC_BASE_URL is configured, content is served from that
+    isolated origin only: requests arriving on any other host (the API
+    origin) are permanently redirected there. Uploaded pages must never
+    execute same-origin with the API — hostile JS could otherwise invoke
+    /api/* with the visitor's cookies attached (issue #20)."""
+    site_base = config.site_public_base_url()
+    if site_base:
+        req_host = (request.headers.get("host") or "").lower()
+        if req_host and req_host != urlparse(site_base).netloc.lower():
+            target = f"{site_base}/a/{app_id}/site" + (f"/{file_path}" if file_path else "")
+            query = str(request.url.query)
+            if query:
+                target = f"{target}?{query}"
+            return RedirectResponse(target, status_code=301)
     site_dir = APPS_DIR / app_id / "site"
     if not site_dir.is_dir():
         raise HTTPException(404, "Site not found")

--- a/tests/test_site_isolation.py
+++ b/tests/test_site_isolation.py
@@ -1,0 +1,83 @@
+"""Isolation of uploaded HTML-app content from the API origin (issue #20).
+
+With SITE_PUBLIC_BASE_URL configured, uploaded pages must execute on that
+host only: the main origin 301-redirects /a/<id>/site/ requests there, and
+generated recipe URLs point at the isolated host. Without it, legacy
+main-origin behaviour is preserved.
+"""
+
+import os
+import unittest
+from unittest import mock
+
+from fastapi.testclient import TestClient
+
+from server import config, main
+
+SANDBOX = "https://s.origin.test"
+ORIGIN = "origin.test"
+
+
+class HtmlSitePublicBaseTests(unittest.TestCase):
+    def test_configured_base_wins_over_request_origin(self):
+        with mock.patch.dict(os.environ, {"SITE_PUBLIC_BASE_URL": SANDBOX}):
+            self.assertEqual(main._html_site_public_base("https://other.test"), SANDBOX)
+
+    def test_unconfigured_falls_back_to_request_origin(self):
+        with mock.patch.dict(os.environ, {"SITE_PUBLIC_BASE_URL": ""}):
+            self.assertEqual(main._html_site_public_base("https://other.test"), "https://other.test")
+            self.assertEqual(main._html_site_public_base(""), "")
+
+    def test_config_strips_trailing_slash(self):
+        with mock.patch.dict(os.environ, {"SITE_PUBLIC_BASE_URL": SANDBOX + "/"}):
+            self.assertEqual(config.site_public_base_url(), SANDBOX)
+
+
+class ServeAppSiteIsolationTests(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(main.app)
+
+    def test_foreign_host_is_redirected_to_sandbox(self):
+        with mock.patch.dict(os.environ, {"SITE_PUBLIC_BASE_URL": SANDBOX}):
+            resp = self.client.get(
+                "/a/someapp/site/index.html",
+                headers={"Host": ORIGIN},
+                follow_redirects=False,
+            )
+        self.assertEqual(resp.status_code, 301)
+        self.assertEqual(resp.headers["location"], f"{SANDBOX}/a/someapp/site/index.html")
+
+    def test_redirect_preserves_query_string(self):
+        with mock.patch.dict(os.environ, {"SITE_PUBLIC_BASE_URL": SANDBOX}):
+            resp = self.client.get(
+                "/a/someapp/site/app.js",
+                params={"v": "2"},
+                headers={"Host": ORIGIN},
+                follow_redirects=False,
+            )
+        self.assertEqual(resp.status_code, 301)
+        self.assertEqual(resp.headers["location"], f"{SANDBOX}/a/someapp/site/app.js?v=2")
+
+    def test_sandbox_host_reaches_serving_logic(self):
+        # Matching host: no redirect — the request proceeds to the serving
+        # logic and fails with 404 for an app that does not exist locally.
+        with mock.patch.dict(os.environ, {"SITE_PUBLIC_BASE_URL": SANDBOX}):
+            resp = self.client.get(
+                "/a/nonexistent/site/index.html",
+                headers={"Host": "s.origin.test"},
+                follow_redirects=False,
+            )
+        self.assertEqual(resp.status_code, 404)
+
+    def test_no_redirect_when_unconfigured(self):
+        with mock.patch.dict(os.environ, {"SITE_PUBLIC_BASE_URL": ""}):
+            resp = self.client.get(
+                "/a/nonexistent/site/index.html",
+                headers={"Host": ORIGIN},
+                follow_redirects=False,
+            )
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Uploaded HTML apps previously executed same-origin with the API surface: hostile JS could call `/api/history/export`, `/api/distill`, etc. with visitor cookies attached, and read the non-HttpOnly fingerprint cookie directly (issue #20).

This PR adds origin isolation driven by a new `SITE_PUBLIC_BASE_URL` env var (e.g. `https://s.example.com`, proxied to the same backend):

- `serve_app_site` 301-redirects `/a/<id>/site/...` requests arriving on any other host to the isolated origin, so uploaded pages only ever execute there.
- Recipe URL derivation for HTML apps (fresh builds **and** history import) points at the isolated origin.
- Cross-site pages cannot carry `SameSite=Lax` cookies to `/api/*`, so uploaded JS loses authenticated API access entirely; `document.cookie` isolation comes free.
- Unset (default) = legacy behaviour, so this deploys safely before the DNS/infra half.

A CSP `sandbox` header was considered and rejected: it also breaks `localStorage` for legitimate uploaded apps (silent data loss for game saves etc.). A dedicated origin has no such trade-off.

## Fixes

Fixes #20

## Test plan

- [x] New `tests/test_site_isolation.py`: URL-derivation preference, foreign-host 301 (incl. query-string preservation), sandbox-host passthrough, legacy no-redirect mode. Full suite: 224 passed.
- [ ] Post-merge ops (same rollout): DNS record for `s.shiaho.sbs`, cert expansion, nginx server block, `SITE_PUBLIC_BASE_URL` in `webtoapp.env`, migration of existing HTML-app recipe URLs, end-to-end verification.
