### PR TITLE
feat(security): gateway key for sandbox-origin content fetches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,3 +89,7 @@ METRICS_TOKEN=
 # /a/<id>/site/ there, so hostile uploaded JS cannot call the API with
 # visitor cookies. Empty = serve from the main origin (legacy behaviour).
 SITE_PUBLIC_BASE_URL=
+# Shared secret presented by the site gateway (e.g. the Cloudflare Worker
+# fronting SITE_PUBLIC_BASE_URL) in X-Site-Origin-Key. Required for the
+# gateway to fetch /a/<id>/site/ content without being 301-redirected.
+SITE_ORIGIN_KEY=

--- a/server/config.py
+++ b/server/config.py
@@ -231,6 +231,18 @@ def site_public_base_url() -> str:
     return os.environ.get("SITE_PUBLIC_BASE_URL", "").strip().rstrip("/")
 
 
+def site_origin_key() -> str:
+    """Shared secret that lets the site gateway skip the sandbox redirect.
+
+    The reverse proxy in front of ``SITE_PUBLIC_BASE_URL`` (e.g. a Cloudflare
+    Worker) presents this in ``X-Site-Origin-Key``; the redirect in
+    ``serve_app_site`` is skipped only for matching requests, so content is
+    still served to the gateway while every direct main-origin request is
+    pushed to the sandbox origin.
+    """
+    return os.environ.get("SITE_ORIGIN_KEY", "").strip()
+
+
 def html_export_max_bytes() -> int:
     """Maximum total site size embedded in an exported history snapshot.
     Larger sites are skipped from the export and flagged instead. Default 2 MB."""

--- a/server/main.py
+++ b/server/main.py
@@ -1407,13 +1407,21 @@ async def serve_app_site(app_id: str, request: Request, file_path: str = ""):
 
     When SITE_PUBLIC_BASE_URL is configured, content is served from that
     isolated origin only: requests arriving on any other host (the API
-    origin) are permanently redirected there. Uploaded pages must never
-    execute same-origin with the API — hostile JS could otherwise invoke
-    /api/* with the visitor's cookies attached (issue #20)."""
+    origin) are permanently redirected there — except calls from the site
+    gateway itself, which proves itself with X-Site-Origin-Key. Uploaded
+    pages must never execute same-origin with the API — hostile JS could
+    otherwise invoke /api/* with the visitor's cookies attached (issue #20)."""
     site_base = config.site_public_base_url()
     if site_base:
+        supplied_key = request.headers.get("x-site-origin-key", "")
+        expected_key = config.site_origin_key()
+        from_gateway = (
+            bool(expected_key)
+            and bool(supplied_key)
+            and secrets.compare_digest(supplied_key, expected_key)
+        )
         req_host = (request.headers.get("host") or "").lower()
-        if req_host and req_host != urlparse(site_base).netloc.lower():
+        if not from_gateway and req_host and req_host != urlparse(site_base).netloc.lower():
             target = f"{site_base}/a/{app_id}/site" + (f"/{file_path}" if file_path else "")
             query = str(request.url.query)
             if query:

--- a/tests/test_site_isolation.py
+++ b/tests/test_site_isolation.py
@@ -78,6 +78,34 @@ class ServeAppSiteIsolationTests(unittest.TestCase):
             )
         self.assertEqual(resp.status_code, 404)
 
+    def test_gateway_key_bypasses_redirect(self):
+        env = {"SITE_PUBLIC_BASE_URL": SANDBOX, "SITE_ORIGIN_KEY": "s3cret"}
+        with mock.patch.dict(os.environ, env):
+            resp = self.client.get(
+                "/a/nonexistent/site/index.html",
+                headers={"Host": ORIGIN, "X-Site-Origin-Key": "s3cret"},
+                follow_redirects=False,
+            )
+        self.assertEqual(resp.status_code, 404)  # reached serving logic, no redirect
+
+    def test_wrong_gateway_key_still_redirects(self):
+        env = {"SITE_PUBLIC_BASE_URL": SANDBOX, "SITE_ORIGIN_KEY": "s3cret"}
+        with mock.patch.dict(os.environ, env):
+            resp = self.client.get(
+                "/a/nonexistent/site/index.html",
+                headers={"Host": ORIGIN, "X-Site-Origin-Key": "nope"},
+                follow_redirects=False,
+            )
+            self.assertEqual(resp.status_code, 301)
+        # No key configured on the server side: any header must be ignored.
+        with mock.patch.dict(os.environ, {"SITE_PUBLIC_BASE_URL": SANDBOX, "SITE_ORIGIN_KEY": ""}):
+            resp = self.client.get(
+                "/a/nonexistent/site/index.html",
+                headers={"Host": ORIGIN, "X-Site-Origin-Key": "s3cret"},
+                follow_redirects=False,
+            )
+        self.assertEqual(resp.status_code, 301)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #26 for the issue #20 rollout. The sandbox origin (`SITE_PUBLIC_BASE_URL`) is fronted by a small reverse proxy (a Cloudflare Worker on a Custom Domain, which auto-creates the DNS record). That gateway fetches `/a/<id>/site/` back from the main origin — which would otherwise 301 straight back to the sandbox host, a redirect loop.

Gateway requests now present a shared secret (`X-Site-Origin-Key`, server-side `SITE_ORIGIN_KEY`, constant-time compared) to skip the redirect. Every other main-origin request is still pushed to the sandbox origin, so the isolation guarantee is unchanged; a wrong or missing key — or no key configured at all — keeps the redirect.

Part of #20 (no closing keyword: #20 closes when the full rollout is verified live).

## Test plan

- [x] `tests/test_site_isolation.py`: correct key bypasses redirect; wrong key redirects; header ignored entirely when no key is configured. Full suite: 226 passed.
- [ ] End-to-end after deploy: Worker-fronted sandbox serves content; main origin redirects browsers but not the keyed gateway.

## Notes

- The Worker itself lives outside the repo (deployed with wrangler, ~20 lines); its behaviour is covered by the gateway-key tests on the origin side.
