### PR TITLE
fix(macos): standalone WKWebView window instead of opening the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Open source · Free · No sign-up. Try it live at **[shiaho.sbs](https://shiaho.
 - **Multi-platform packaging**: builds installers for five platforms at once
   - **Android** — a real, installable WebView APK (v1+v2+v3 signed). Each app uses its **own dedicated signing certificate**.
   - **iOS** — a `.mobileconfig` Web Clip profile, with optional CMS signing using a public-CA certificate ("signature-free" install).
-  - **Windows / macOS / Linux** — lightweight launchers with a native icon.
+  - **Windows / macOS / Linux** — lightweight launchers with a native icon. On macOS the app opens as a standalone WKWebView window (no address bar, no third-party browser needed); Windows / Linux open the system browser in app mode.
 - **iOS dynamic URL swap**: the Web Clip points at `/a/<id>/launch`, so you can change the target URL on the server without reinstalling.
 - **History**: build history is saved per device fingerprint, with export / import to other devices.
 - **Auto cleanup**: apps with no visits for 30 days are automatically reclaimed.
@@ -51,7 +51,7 @@ Open source · Free · No sign-up. Try it live at **[shiaho.sbs](https://shiaho.
 
 ## App size
 
-Each package is just a thin entry point to your site — it bundles no site content, so the artifacts are measured in **kilobytes, not megabytes**. Under the hood it uses each platform's native lightweight shell: an Android WebView APK, an iOS Web Clip profile, and `.app` / `.bat` / `.desktop` launchers that open the system browser in app mode on desktop.
+Each package is just a thin entry point to your site — it bundles no site content, so the artifacts are measured in **kilobytes, not megabytes**. Under the hood it uses each platform's native lightweight shell: an Android WebView APK, an iOS Web Clip profile, a standalone WKWebView `.app` window on macOS, and `.bat` / `.desktop` launchers that open the system browser in app mode on Windows / Linux.
 
 Measured on a real build (figures are representative; they barely vary by site):
 
@@ -59,7 +59,7 @@ Measured on a real build (figures are representative; they barely vary by site):
 | --- | --- | --- | --- |
 | Android | `android.apk` | **~21 KB** | A real, installable WebView APK (v1+v2+v3 signed) |
 | iOS / iPadOS | `ios.mobileconfig` | **~4 KB** | A Web Clip configuration profile |
-| macOS | `macos.zip` | **~1.4 KB** | A `.app` bundle (launcher script + icon) |
+| macOS | `macos.zip` | **~1.4 KB** | A `.app` bundle (standalone WKWebView window launcher + icon) |
 | Windows | `windows.zip` | **~1.2 KB** | A `.bat` launcher + desktop-shortcut helper + icon |
 | Linux | `linux.tar.gz` | **~0.7 KB** | A `.desktop` entry + install script + icon |
 

--- a/server/engine/distiller.py
+++ b/server/engine/distiller.py
@@ -5,6 +5,7 @@ Each platform gets a real, installable, few-KB launcher with proper app icon.
 
 import json
 import re
+import shlex
 import uuid
 import secrets
 import zipfile
@@ -27,6 +28,64 @@ from server import html_site
 from server.htmlmeta import parse_html_metadata
 from server.logging_util import log_event
 from server.net import fetch_public_url_bytes
+
+
+# Standalone-window runtime for the macOS .app launcher: a tiny JXA script that
+# opens the target URL in a real WKWebView window using only system frameworks —
+# no bundled binaries, nothing to codesign. Kept as a static string so the
+# shipped file is byte-identical to what is tested locally. The launcher feeds
+# it WTA_URL / WTA_NAME / WTA_ICON through the environment.
+_MACOS_WEBVIEW_APP_JS = """\
+ObjC.import('Cocoa');
+ObjC.import('WebKit');
+
+(function () {
+  var env = $.NSProcessInfo.processInfo.environment;
+  function envStr(key) { var v = env.objectForKey(key); return v ? v.js : ''; }
+  var url = envStr('WTA_URL');
+  var name = envStr('WTA_NAME') || 'App';
+  var iconPath = envStr('WTA_ICON');
+  if (!/^https:\\/\\//i.test(url)) {
+    // App Transport Security blocks plain-http loads inside WKWebView; exit
+    // non-zero so the shell launcher falls back to browser app mode.
+    throw new Error('WTA: embedded WebView requires an https target');
+  }
+  var app = $.NSApplication.sharedApplication;
+  app.setActivationPolicy(0); // regular app: own dock icon + menu bar presence
+  app.activateIgnoringOtherApps(true);
+  if (iconPath) {
+    var img = $.NSImage.alloc.initWithContentsOfFile(iconPath);
+    if (img && !img.isNil()) { app.setApplicationIconImage(img); }
+  }
+  var W = 1280;
+  var H = 800;
+  var frame = $.NSMakeRect(0, 0, W, H);
+  var win = $.NSWindow.alloc.initWithContentRectStyleMaskBackingDefer(frame, 15, 2, false);
+  win.setTitle(name);
+  var screen = $.NSScreen.mainScreen.frame;
+  var x = screen.origin.x + (screen.size.width - W) / 2;
+  var y = screen.origin.y + (screen.size.height - H) / 2;
+  win.setFrameDisplay($.NSMakeRect(x, y, W, H), true);
+  var wv = $.WKWebView.alloc.initWithFrame(frame);
+  win.contentView = wv;
+  // Quit the whole app when the window closes. NSWindow does not retain its
+  // delegate, so the instance must stay alive in this scope while run() spins.
+  ObjC.registerSubclass({
+    name: 'WTALauncherDelegate',
+    methods: {
+      'windowWillClose:': {
+        types: ['void', ['id']],
+        implementation: function () { $.NSApp.terminate(null); }
+      }
+    }
+  });
+  var delegate = $.WTALauncherDelegate.alloc.init;
+  win.setDelegate(delegate);
+  wv.loadRequest($.NSURLRequest.requestWithURL($.NSURL.URLWithString(url)));
+  win.makeKeyAndOrderFront(null);
+  app.run();
+})();
+"""
 
 
 class Distiller:
@@ -1430,13 +1489,25 @@ WScript.Echo "桌面快捷方式已创建！"
     # ===== macOS — .app bundle + .icns =====
     def _build_macos(self, dl: Path, r: dict, icon_png, launch_url):
         n = r['name']
-        # Prefer a Chromium-family browser's "app mode" (--app=URL), which opens
-        # a chromeless standalone window (no tabs, no address bar) — the closest
-        # thing to a native app on macOS. We probe a list of common Chromium
-        # browsers by bundle path. Safari has no chromeless CLI mode, so on a
-        # Safari-only Mac we fall back to a plain open (with browser chrome).
+        # Launch chain, best experience first:
+        #   1. A real WKWebView window driven by the system osascript (JXA) — a
+        #      genuine standalone app window on every Mac with no third-party
+        #      browser required. The previous Chromium-only probe left Safari-only
+        #      Macs falling through to a plain `open`, i.e. a full-chrome browser
+        #      tab. app.js refuses plain-http targets (ATS blocks them inside
+        #      WKWebView) and exits non-zero so the shell falls through.
+        #   2. A Chromium-family browser's "app mode" (--app=URL) — chromeless
+        #      window on the user's own browser engine.
+        #   3. The default browser as a last resort.
         launcher = f"""#!/bin/bash
-URL="{launch_url}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+RES="$DIR/../Resources"
+export WTA_URL={shlex.quote(launch_url)}
+export WTA_NAME={shlex.quote(n)}
+export WTA_ICON="$RES/AppIcon.icns"
+if /usr/bin/osascript -l JavaScript "$RES/app.js"; then
+    exit 0
+fi
 CHROMIUM_APPS=(
     "Google Chrome"
     "Google Chrome Canary"
@@ -1449,12 +1520,11 @@ CHROMIUM_APPS=(
 )
 for app in "${{CHROMIUM_APPS[@]}}"; do
     if [ -d "/Applications/$app.app" ] || [ -d "$HOME/Applications/$app.app" ]; then
-        open -na "$app" --args --app="$URL"
+        open -na "$app" --args --app="$WTA_URL"
         exit 0
     fi
 done
-# No Chromium-family browser found: open in the default browser.
-open "$URL"
+open "$WTA_URL"
 """
         plist = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -1471,6 +1541,7 @@ open "$URL"
             info = zipfile.ZipInfo(f"{n}.app/Contents/MacOS/launcher")
             info.external_attr = 0o755 << 16
             z.writestr(info, launcher)
+            z.writestr(f"{n}.app/Contents/Resources/app.js", _MACOS_WEBVIEW_APP_JS)
             z.writestr(f"{n}.app/Contents/Info.plist", plist)
             if icon_png:
                 z.writestr(f"{n}.app/Contents/Resources/AppIcon.icns", self._png_to_icns(icon_png))

--- a/tests/test_distiller.py
+++ b/tests/test_distiller.py
@@ -72,3 +72,62 @@ class DistillerWriteAppFilesTests(unittest.TestCase):
             self.assertIn("done", stages)
             android_mock.assert_called_once()
             ios_mock.assert_called_once()
+
+
+class DistillerMacosLauncherTests(unittest.TestCase):
+    def _build(self, name="My App", url="https://example.com"):
+        import shlex
+        import tempfile
+        import zipfile
+        from pathlib import Path
+
+        distiller = Distiller()
+        recipe = {"id": "abcd1234", "name": name}
+        with tempfile.TemporaryDirectory() as tmp:
+            distiller._build_macos(Path(tmp), recipe, None, url)
+            entries = {}
+            modes = {}
+            with zipfile.ZipFile(Path(tmp) / "macos.zip") as z:
+                for info in z.infolist():
+                    entries[info.filename] = z.read(info.filename).decode()
+                    modes[info.filename] = (info.external_attr >> 16) & 0o7777
+        return entries, modes
+
+    def test_launcher_tries_webview_then_browser_fallbacks(self):
+        import shlex
+
+        entries, modes = self._build(url="https://example.com/x")
+        launcher = entries["My App.app/Contents/MacOS/launcher"]
+        self.assertTrue(launcher.startswith("#!/bin/bash"))
+        # Preferred path: system WKWebView window via osascript.
+        self.assertIn("/usr/bin/osascript -l JavaScript", launcher)
+        self.assertIn(f"export WTA_URL={shlex.quote('https://example.com/x')}", launcher)
+        # Fallbacks: Chromium app mode, then the default browser.
+        self.assertIn("open -na", launcher)
+        self.assertLess(launcher.index("osascript"), launcher.index("open -na"))
+        self.assertIn('open "$WTA_URL"', launcher)
+        self.assertGreater(launcher.index('open "$WTA_URL"'), launcher.index("open -na"))
+        # The WebView runtime ships inside the bundle and drives a real window.
+        app_js = entries["My App.app/Contents/Resources/app.js"]
+        self.assertIn("WKWebView", app_js)
+        self.assertIn("windowWillClose:", app_js)
+        self.assertIn("WTA_URL", app_js)
+        # Launcher stays executable through the zip round-trip.
+        self.assertEqual(modes["My App.app/Contents/MacOS/launcher"], 0o755)
+
+    def test_launcher_shell_quotes_names_and_urls(self):
+        import shlex
+
+        tricky_name = "Bob's \"App\""
+        tricky_url = "https://example.com/?q=it's&a=$b"
+        entries, _ = self._build(name=tricky_name, url=tricky_url)
+        launcher = entries[f"{tricky_name}.app/Contents/MacOS/launcher"]
+        self.assertIn(f"export WTA_URL={shlex.quote(tricky_url)}", launcher)
+        self.assertIn(f"export WTA_NAME={shlex.quote(tricky_name)}", launcher)
+
+    def test_webview_runtime_rejects_http_targets(self):
+        entries, _ = self._build(url="http://example.com")
+        app_js = entries["My App.app/Contents/Resources/app.js"]
+        # ATS blocks plain http inside WKWebView; app.js must bail out (non-zero
+        # exit) so the shell launcher falls through to browser app mode.
+        self.assertIn("requires an https target", app_js)


### PR DESCRIPTION
## Summary

On macOS the generated `.app` opened the target site in the default browser (full chrome) unless one of the probed Chromium-family browsers happened to be installed — Safari-only Macs got a plain `open`, i.e. a browser tab, not an app window. Behavior varied per machine.

The launcher now first drives the system `osascript` (JXA) to open a real **WKWebView** window: pure system frameworks, nothing to codesign, works on every Mac with its own dock icon and no address bar. `app.js` refuses plain-http targets (ATS blocks http inside WKWebView) and exits non-zero so the shell falls through to the previous chain: Chromium-family app mode → default browser. URLs and app names are shell-quoted via `shlex.quote`.

iOS is **not** affected by this bug: the Web Clip always ships `FullScreen=true` (standalone launch) and never uses the desktop launcher; CMS signing only changes the install-time trust warning.

## Fixes

Fixes #28

## Test plan

- [x] `python3 -m pytest tests/` — 229 passed (3 new tests: launch chain order, shell quoting of names/URLs, http rejection in app.js).
- [x] End-to-end on macOS 15 (arm64): built a real `macos.zip` via `Distiller._build_macos`, unzipped, launched `.app/Contents/MacOS/launcher` on a Mac **without any Chromium browser in the probe list hitting first** — WKWebView window appears and stays up; closing it terminates the process.
- [x] http:// target: app.js exits non-zero immediately, launcher falls back (verified exit code).
- [ ] After deploy: rebuild an app on shiaho.sbs, install the new `macos.zip`, confirm double-click opens a standalone window.

## Notes for review

- The JXA runtime is shipped as a static string (`_MACOS_WEBVIEW_APP_JS`) so the tested file is byte-identical to what ships; it reads `WTA_URL` / `WTA_NAME` / `WTA_ICON` from the environment set by the launcher.
- Known cosmetic limitation: the menu-bar app name shows as `osascript` (no bundle rename without shipping a compiled binary); the window title and dock icon are correct.
- Existing apps keep their old `macos.zip`; users get the fixed launcher on the next build. Android-only rebuild script does not touch macOS artifacts.
- Localized READMEs (docs/*.md) intentionally not updated in this PR to keep the diff focused.