### PR TITLE
工作区布局打磨：标题竖排、Tab 溢出隐藏、零值误标红

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -416,11 +416,14 @@ section {
 }
 
 .analysis-item .label {
+  flex-shrink: 0;
   color: var(--ink-soft);
   font-size: 0.92rem;
 }
 
 .analysis-item .value {
+  min-width: 0;
+  overflow-wrap: anywhere;
   font-weight: 600;
   text-align: right;
 }
@@ -941,11 +944,14 @@ section {
   background: rgba(252, 249, 244, 0.8);
 }
 
+/* Stacked (not side-by-side): the sub-copy is too long in most languages to
+   share one row inside a ~430px column — side-by-side squeezed the title
+   into vertical one-character-per-line stacking. */
 .platform-config-head {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
   padding: 16px 18px 0;
 }
 
@@ -958,19 +964,18 @@ section {
 .platform-config-head small {
   color: rgba(30, 25, 20, 0.46);
   font-size: 0.84rem;
-  text-align: right;
-  white-space: nowrap;
+  line-height: 1.6;
 }
 
+/* Wrapped pills, not a scroller: five tabs physically cannot fit a ~394px
+   row, so horizontal scrolling always hid the last tab (Linux) with zero
+   affordance. Wrapping keeps every platform one tap away. */
 .platform-tabs {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-top: 14px;
   padding: 0 18px 12px;
-  overflow-x: auto;
-  scrollbar-width: thin;
-  -webkit-overflow-scrolling: touch;
-  scroll-snap-type: x proximity;
 }
 
 .platform-tab {
@@ -986,7 +991,6 @@ section {
   color: rgba(30, 25, 20, 0.62);
   font-size: 0.88rem;
   font-weight: 600;
-  scroll-snap-align: start;
   transition: border-color var(--transition), background var(--transition), color var(--transition);
 }
 
@@ -1654,15 +1658,13 @@ section {
   }
 
   .feature-panel summary,
-  .advanced-panel summary,
-  .platform-config-head {
+  .advanced-panel summary {
     flex-direction: column;
     align-items: flex-start;
   }
 
   .feature-panel summary small,
-  .advanced-panel summary small,
-  .platform-config-head small {
+  .advanced-panel summary small {
     text-align: left;
   }
 

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif+SC:wght@400;500;600;700;900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css?v=20260904-polish1">
-  <script src="js/i18n.js?v=20260904-polish1"></script>
-  <script src="js/i18n.strings.js?v=20260904-polish1"></script>
+  <link rel="stylesheet" href="css/style.css?v=20260904-layout1">
+  <script src="js/i18n.js?v=20260904-layout1"></script>
+  <script src="js/i18n.strings.js?v=20260904-layout1"></script>
 </head>
 <body>
   <canvas id="bg"></canvas>
@@ -399,6 +399,6 @@
 
   </main>
 
-  <script src="js/app.v5.js?v=20260904-polish1"></script>
+  <script src="js/app.v5.js?v=20260904-layout1"></script>
 </body>
 </html>

--- a/js/app.v5.js
+++ b/js/app.v5.js
@@ -1182,9 +1182,9 @@
         <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.suggestedName'))}</span><span class="value good">${escapeHtml(suggestedName)}</span></div>
         <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.nameSource'))}</span><span class="value info">${escapeHtml(suggestedNameSourceLabel)}</span></div>
         <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.iconStatus'))}</span><span class="value ${data.faviconDataUrl ? 'good' : 'info'}">${escapeHtml(data.faviconDataUrl ? t('analysis.iconAutoFetched') : t('analysis.iconNotDetected'))}</span></div>
-        <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.adsDetected'))}</span><span class="value bad">${escapeHtml(t('analysis.adsUnit', { n: data.ads }))}</span></div>
-        <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.trackers'))}</span><span class="value bad">${escapeHtml(t('analysis.trackersUnit', { n: data.trackers }))}</span></div>
-        <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.popups'))}</span><span class="value bad">${escapeHtml(t('analysis.popupsUnit', { n: data.popups }))}</span></div>
+        <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.adsDetected'))}</span><span class="value ${Number(data.ads) > 0 ? 'bad' : 'good'}">${escapeHtml(t('analysis.adsUnit', { n: data.ads }))}</span></div>
+        <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.trackers'))}</span><span class="value ${Number(data.trackers) > 0 ? 'bad' : 'good'}">${escapeHtml(t('analysis.trackersUnit', { n: data.trackers }))}</span></div>
+        <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.popups'))}</span><span class="value ${Number(data.popups) > 0 ? 'bad' : 'good'}">${escapeHtml(t('analysis.popupsUnit', { n: data.popups }))}</span></div>
         <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.originalSize'))}</span><span class="value">${escapeHtml(String(data.originalSize))}</span></div>
         <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.distilledSize'))}</span><span class="value good">${escapeHtml(String(data.distilledSize))}</span></div>
         <div class="analysis-item"><span class="label">${escapeHtml(t('analysis.speedBoost'))}</span><span class="value good">${escapeHtml(String(data.speedBoost))}</span></div>


### PR DESCRIPTION
Fixes #40

## Summary
- 平台设置头改纵向堆叠：长副文案曾把标题挤成一字一行竖排。
- Tab 栏横滑改自动换行：430px 列放不下 5 个签，横滑等于藏起 Linux 页签且无提示。
- 广告/追踪/弹窗为 0 显示绿色，>0 才红；分析行加防溢出。
- `?v=` bump 到 `20260904-layout1`。

## Test plan
- `python3 -m pytest tests/` 本地 239 passed；`node --check` 通过；CSS 括号配平、HTML 可解析。
- 待 CI `test (3.11)` 绿后合并；合并后同步生产服验证。