### PR TITLE
高级设置副标题 nowrap 导致工作区横向溢出

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -644,6 +644,15 @@ section {
   list-style: none;
 }
 
+/* Stacked override: the Android tab column (~430px) cannot fit title +
+   a nowrap sub like "Android version and package name" side by side —
+   it blew the summary (and the page) out horizontally. */
+.advanced-panel summary {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
 .feature-panel summary::-webkit-details-marker,
 .advanced-panel summary::-webkit-details-marker {
   display: none;
@@ -662,6 +671,12 @@ section {
   font-size: 0.84rem;
   text-align: right;
   white-space: nowrap;
+}
+
+.advanced-panel summary small {
+  text-align: left;
+  white-space: normal;
+  line-height: 1.6;
 }
 
 .feature-grid {
@@ -1657,14 +1672,12 @@ section {
     border-radius: 18px;
   }
 
-  .feature-panel summary,
-  .advanced-panel summary {
+  .feature-panel summary {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .feature-panel summary small,
-  .advanced-panel summary small {
+  .feature-panel summary small {
     text-align: left;
   }
 

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif+SC:wght@400;500;600;700;900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css?v=20260904-noads1">
-  <script src="js/i18n.js?v=20260904-noads1"></script>
-  <script src="js/i18n.strings.js?v=20260904-noads1"></script>
+  <link rel="stylesheet" href="css/style.css?v=20260904-advfix1">
+  <script src="js/i18n.js?v=20260904-advfix1"></script>
+  <script src="js/i18n.strings.js?v=20260904-advfix1"></script>
 </head>
 <body>
   <canvas id="bg"></canvas>
@@ -399,6 +399,6 @@
 
   </main>
 
-  <script src="js/app.v5.js?v=20260904-noads1"></script>
+  <script src="js/app.v5.js?v=20260904-advfix1"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #44

## Summary
- 高级设置头改纵向堆叠，副文案换行；删冗余媒体查询规则。
- `?v=` bump 到 `20260904-advfix1`。

## Test plan
- `pytest` 239 passed；级联顺序已校验（后规则同优先级覆盖）。
- CI 绿后合并并同步生产服。