### PR TITLE
首页三槽改成生成 / 下载 / 浏览

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif+SC:wght@400;500;600;700;900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css?v=20260904-advfix1">
-  <script src="js/i18n.js?v=20260904-advfix1"></script>
-  <script src="js/i18n.strings.js?v=20260904-advfix1"></script>
+  <link rel="stylesheet" href="css/style.css?v=20260904-stats1">
+  <script src="js/i18n.js?v=20260904-stats1"></script>
+  <script src="js/i18n.strings.js?v=20260904-stats1"></script>
 </head>
 <body>
   <canvas id="bg"></canvas>
@@ -76,8 +76,8 @@
 
           <div class="stats">
             <div class="stat"><strong id="stat-generated-apps" data-count="0">0</strong><span data-i18n="stats.generated">apps generated</span></div>
-            <div class="stat"><strong id="stat-supported-platforms" data-count="0">0</strong><span data-i18n="stats.platforms">supported platforms</span></div>
-            <div class="stat"><strong id="stat-shared-recipes" data-count="0">0</strong><span data-i18n="stats.recipes">shared recipes</span></div>
+            <div class="stat"><strong id="stat-downloads" data-count="0">0</strong><span data-i18n="stats.downloads">downloads</span></div>
+            <div class="stat"><strong id="stat-views" data-count="0">0</strong><span data-i18n="stats.views">page views</span></div>
           </div>
         </div>
       </div>
@@ -399,6 +399,6 @@
 
   </main>
 
-  <script src="js/app.v5.js?v=20260904-advfix1"></script>
+  <script src="js/app.v5.js?v=20260904-stats1"></script>
 </body>
 </html>

--- a/js/app.v5.js
+++ b/js/app.v5.js
@@ -89,8 +89,8 @@
       const stats = await res.json();
       const mappings = [
         ['stat-generated-apps', stats.generatedApps],
-        ['stat-supported-platforms', stats.supportedPlatforms],
-        ['stat-shared-recipes', stats.sharedRecipes],
+        ['stat-downloads', stats.downloads],
+        ['stat-views', stats.views],
       ];
       mappings.forEach(([id, value]) => {
         const el = document.getElementById(id);

--- a/js/i18n.strings.js
+++ b/js/i18n.strings.js
@@ -37,6 +37,8 @@
     'hero.urlPlaceholder': 'Enter a website link',
     'hero.startBtn': 'Get started',
     'stats.generated': 'apps generated',
+    'stats.downloads': 'downloads',
+    'stats.views': 'page views',
     'stats.platforms': 'supported platforms',
     'stats.recipes': 'shared recipes',
 
@@ -241,6 +243,8 @@
     'hero.urlPlaceholder': '输入网站链接',
     'hero.startBtn': '开始创建',
     'stats.generated': '个应用已生成',
+    'stats.downloads': '次下载',
+    'stats.views': '次浏览',
     'stats.platforms': '个支持平台',
     'stats.recipes': '共享配方',
 

--- a/server/history_store.py
+++ b/server/history_store.py
@@ -658,3 +658,31 @@ class HistoryStore:
             apps = self._conn.execute("SELECT COUNT(*) AS c FROM apps").fetchone()["c"]
             devices = self._conn.execute("SELECT COUNT(*) AS c FROM devices").fetchone()["c"]
             return {"backend": "sqlite", "apps": apps, "devices": devices, "db_path": str(self.db_path)}
+
+    def traffic_totals(self) -> dict:
+        """Homepage counters across all apps (flushes the pending buffer first).
+
+        views: pure page views (landing + install + pwa + launch channels).
+        downloads: per-platform download events summed from downloads_json.
+        Both cover surviving apps only: the 30-day retention purge deletes an
+        app's visits row along with the app itself.
+        """
+        with self._lock:
+            self._flush_visits_locked()
+            row = self._conn.execute(
+                "SELECT COALESCE(SUM(landing + install + pwa + launch), 0) AS views FROM visits"
+            ).fetchone()
+            views = int(row["views"] or 0)
+            downloads = 0
+            for (blob,) in self._conn.execute("SELECT downloads_json FROM visits"):
+                try:
+                    data = json.loads(blob or "{}")
+                except Exception:
+                    continue
+                if isinstance(data, dict):
+                    downloads += sum(
+                        int(value or 0)
+                        for value in data.values()
+                        if isinstance(value, (int, float))
+                    )
+            return {"views": views, "downloads": downloads}

--- a/server/main.py
+++ b/server/main.py
@@ -137,7 +137,6 @@ http_client = httpx.AsyncClient(
     timeout=30.0,
     headers={"User-Agent": "WebToApp/1.0 (+https://github.com/)"},
 )
-SUPPORTED_PLATFORM_COUNT = 5
 DISTILL_WORKER_COUNT = config.distill_worker_count()
 RECIPE_CACHE_SIZE = config.recipe_cache_size()
 DISTILL_TASK_TTL_SECONDS = 6 * 60 * 60
@@ -1130,11 +1129,11 @@ async def popular_recipes():
 @app.get("/api/stats")
 async def homepage_stats():
     app_count = sum(1 for _ in APPS_DIR.glob("*/recipe.json"))
-    recipe_count = len(recipes.get_popular())
+    traffic = history_store.traffic_totals()
     return {
         "generatedApps": app_count,
-        "supportedPlatforms": SUPPORTED_PLATFORM_COUNT,
-        "sharedRecipes": recipe_count,
+        "downloads": traffic["downloads"],
+        "views": traffic["views"],
     }
 
 

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -64,6 +64,20 @@ class HistoryStoreSqliteTests(unittest.TestCase):
             self.assertEqual([i["app_id"] for i in items][:2], ["app2", "app1"])
             self.assertEqual(store.stats()["apps"], 2)
 
+    def test_traffic_totals_splits_views_and_downloads(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = HistoryStore(Path(tmp) / "_history.json")
+            store.record_visit("app1", "landing")
+            store.record_visit("app1", "landing")
+            store.record_visit("app1", "download:android")
+            store.record_visit("app2", "install")
+            store.record_visit("app2", "download:ios")
+            store.record_visit("app2", "download:ios")
+            totals = store.traffic_totals()
+            # Pure page views only; download events counted separately.
+            self.assertEqual(totals["views"], 3)
+            self.assertEqual(totals["downloads"], 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #47

## Summary
- 后端 `traffic_totals`＋`/api/stats` 三槽；前端替换映射＋i18n；`?v=20260904-stats1`。
- 口径：浏览＝纯页面访问，下载＝各端下载事件求和；均为现存应用累计（30 天回收会连数删除）。

## Test plan
- `pytest` 245 passed（含新增 traffic_totals 用例）；`node --check` 通过。
- CI 绿后合并＋部署，线上核对三数。