### PR TITLE
入口 index.html 无缓存头，用户被旧页面滞留

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -107,7 +107,14 @@ async def add_cache_headers(request: Request, call_next):
     existing = response.headers.get("cache-control")
     if existing:
         return response
-    if path.startswith(_LONG_CACHE_PREFIXES) or path.endswith(_LONG_CACHE_SUFFIXES):
+    if path in ("/", "/index.html"):
+        # Entry HTML must revalidate on every load. All frontend upgrades
+        # ride on ?v= cache-busters *inside* this file, so a heuristically
+        # cached copy strands users on stale UI talking to a new API
+        # (all-zero stats, missing panels). StaticFiles emits ETag and
+        # Last-Modified, so this costs a cheap 304, not a full download.
+        response.headers["Cache-Control"] = "no-cache"
+    elif path.startswith(_LONG_CACHE_PREFIXES) or path.endswith(_LONG_CACHE_SUFFIXES):
         # 1 day fresh, 7 days stale-while-revalidate. Hashed query strings
         # (?v=...) used in index.html keep these effectively immutable.
         response.headers["Cache-Control"] = "public, max-age=86400, stale-while-revalidate=604800"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
 
+from fastapi.testclient import TestClient
+
 from server import main
 
 
@@ -80,3 +82,22 @@ class MainHelpersTests(unittest.TestCase):
                 main.RECIPE_CACHE_SIZE = original_cache_size
                 with main._recipe_cache_lock:
                     main._recipe_cache.clear()
+
+
+class EntryCacheHeaderTests(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(main.app)
+
+    def test_root_html_must_revalidate(self):
+        # Stale entry HTML + fresh ?v= assets inside it = users stranded on
+        # old UI talking to a new API (all-zero stats). no-cache forces a
+        # cheap 304 revalidation instead of heuristic caching.
+        for path in ("/", "/index.html"):
+            resp = self.client.get(path)
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get("cache-control"), "no-cache")
+
+    def test_versioned_assets_stay_long_cached(self):
+        resp = self.client.get("/css/style.css")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("max-age=86400", resp.headers.get("cache-control", ""))


### PR DESCRIPTION
Fixes #49

## Summary
- 中间件对 / 与 /index.html 发 no-cache；版本化资源长缓存不动。
- 2 个新测试。

## Test plan
- pytest 247 passed；CI 绿后合并＋部署。部署后用户需强制刷新一次（拿掉最后一份旧 HTML），历史点“恢复已有构建”即回。