### PR TITLE
feat(hero): drop oversized headline, center the input card

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -131,39 +131,11 @@ section {
   width: min(1360px, 100%);
   margin: 0 auto;
   display: grid;
-  grid-template-columns: minmax(0, 1.04fr) minmax(380px, 0.96fr);
-  gap: clamp(26px, 4vw, 56px);
-  align-items: start;
-}
-
-.hero-copy {
-  max-width: 38rem;
-  padding-top: 8px;
-}
-
-.hero-kicker {
-  margin-bottom: 18px;
-  color: var(--ink-faint);
-  font-size: 0.78rem;
-  letter-spacing: 0.18em;
-}
-
-#hero h1 {
-  max-width: 6.2ch;
-  font-family: var(--font-serif);
-  font-size: clamp(4rem, 8vw, 6.8rem);
-  line-height: 0.94;
-  letter-spacing: 0;
-  font-weight: 700;
-  color: var(--ink);
-}
-
-.gradient-text {
-  color: rgba(30, 25, 20, 0.86);
+  grid-template-columns: minmax(0, 640px);
+  justify-content: center;
 }
 
 .hero-side {
-  max-width: 35rem;
   padding: 24px 28px 24px;
   border: 1px solid var(--line);
   border-radius: var(--radius-xl);
@@ -1576,17 +1548,6 @@ section {
 }
 
 @media (max-width: 1100px) {
-  .hero-grid {
-    grid-template-columns: 1fr;
-  }
-
-  #hero h1,
-  .hero-copy,
-  .hero-body,
-  .hero-side {
-    max-width: none;
-  }
-
   .workspace-grid {
     grid-template-columns: 1fr;
   }
@@ -1612,14 +1573,6 @@ section {
     min-height: auto;
     padding-top: 12px;
     padding-bottom: 36px;
-  }
-
-  .hero-grid {
-    gap: 24px;
-  }
-
-  #hero h1 {
-    font-size: clamp(3.2rem, 15vw, 5rem);
   }
 
   .hero-side {
@@ -1830,7 +1783,6 @@ section {
   padding: 8px 14px 8px 34px;
 }
 
-[dir="rtl"] .hero-kicker,
 [dir="rtl"] .history-kicker {
   letter-spacing: 0;
 }

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif+SC:wght@400;500;600;700;900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css?v=20260904-stats1">
-  <script src="js/i18n.js?v=20260904-stats1"></script>
-  <script src="js/i18n.strings.js?v=20260904-stats1"></script>
+  <link rel="stylesheet" href="css/style.css?v=20260908-hero1">
+  <script src="js/i18n.js?v=20260908-hero1"></script>
+  <script src="js/i18n.strings.js?v=20260908-hero1"></script>
 </head>
 <body>
   <canvas id="bg"></canvas>
@@ -44,10 +44,6 @@
     <!-- ===== HERO ===== -->
     <section id="hero">
       <div class="hero-grid">
-        <div class="hero-copy" data-reveal>
-          <p class="hero-kicker" data-i18n="hero.kicker">WEBTOAPP / WEBSITE TO APP</p>
-          <h1><span data-i18n="hero.titleLine1">Turn websites</span><br><span class="gradient-text" data-i18n="hero.titleLine2">into apps.</span></h1>
-        </div>
         <div class="hero-side" data-reveal>
           <div class="badge" data-i18n="hero.badge">Open source · Free · No sign-up</div>
           <p class="subtitle" data-i18n="hero.subtitle">Enter a link. Seconds later it can be installed, shared and used like an app. From iPhone to desktop, it is the same generated result.</p>
@@ -399,6 +395,6 @@
 
   </main>
 
-  <script src="js/app.v5.js?v=20260904-stats1"></script>
+  <script src="js/app.v5.js?v=20260908-hero1"></script>
 </body>
 </html>

--- a/js/i18n.strings.js
+++ b/js/i18n.strings.js
@@ -29,9 +29,6 @@
     'nav.langLabel': 'Language',
     'nav.github': 'View source on GitHub',
 
-    'hero.kicker': 'WEBTOAPP / WEBSITE TO APP',
-    'hero.titleLine1': 'Turn websites',
-    'hero.titleLine2': 'into apps.',
     'hero.badge': 'Open source · Free · No sign-up',
     'hero.subtitle': 'Enter a link. Seconds later it can be installed, shared and used like an app. From iPhone to desktop, it is the same generated result.',
     'hero.urlPlaceholder': 'Enter a website link',
@@ -235,9 +232,6 @@
     'nav.langLabel': '语言',
     'nav.github': '在 GitHub 上查看源码',
 
-    'hero.kicker': 'WEBTOAPP / 网站到应用',
-    'hero.titleLine1': '把网站',
-    'hero.titleLine2': '做成应用。',
     'hero.badge': '开源 · 免费 · 无需登录',
     'hero.subtitle': '输入一个链接。几秒钟后，它就能被安装、被分享，也能像应用一样被使用。从 iPhone 到桌面端，用的是同一套生成结果。',
     'hero.urlPlaceholder': '输入网站链接',
@@ -441,9 +435,6 @@
     'nav.langLabel': '言語',
     'nav.github': 'GitHub でソースを見る',
 
-    'hero.kicker': 'WEBTOAPP / ウェブからアプリへ',
-    'hero.titleLine1': 'ウェブサイトを',
-    'hero.titleLine2': 'アプリに。',
     'hero.badge': 'オープンソース · 無料 · 登録不要',
     'hero.subtitle': 'リンクを入力するだけ。数秒後にはインストール・共有でき、アプリのように使えます。iPhone からデスクトップまで、同じ生成結果が使えます。',
     'hero.urlPlaceholder': 'ウェブサイトのリンクを入力',
@@ -623,9 +614,6 @@
     'nav.langLabel': 'اللغة',
     'nav.github': 'عرض المصدر على GitHub',
 
-    'hero.kicker': 'WEBTOAPP / من الموقع إلى التطبيق',
-    'hero.titleLine1': 'حوّل المواقع',
-    'hero.titleLine2': 'إلى تطبيقات.',
     'hero.badge': 'مفتوح المصدر · مجاني · بدون تسجيل',
     'hero.subtitle': 'أدخل رابطًا. خلال ثوانٍ يمكن تثبيته ومشاركته واستخدامه كتطبيق. من iPhone إلى سطح المكتب، النتيجة المُولّدة واحدة.',
     'hero.urlPlaceholder': 'أدخل رابط الموقع',
@@ -805,9 +793,6 @@
     'nav.langLabel': 'Язык',
     'nav.github': 'Открыть исходный код на GitHub',
 
-    'hero.kicker': 'WEBTOAPP / САЙТ В ПРИЛОЖЕНИЕ',
-    'hero.titleLine1': 'Превратите сайты',
-    'hero.titleLine2': 'в приложения.',
     'hero.badge': 'Открытый код · Бесплатно · Без регистрации',
     'hero.subtitle': 'Введите ссылку. Через несколько секунд её можно установить, отправить и использовать как приложение. От iPhone до десктопа — один и тот же результат.',
     'hero.urlPlaceholder': 'Введите ссылку на сайт',
@@ -987,9 +972,6 @@
     'nav.langLabel': 'Idioma',
     'nav.github': 'Ver el código en GitHub',
 
-    'hero.kicker': 'WEBTOAPP / DEL SITIO A LA APP',
-    'hero.titleLine1': 'Convierte sitios web',
-    'hero.titleLine2': 'en aplicaciones.',
     'hero.badge': 'Código abierto · Gratis · Sin registro',
     'hero.subtitle': 'Introduce un enlace. En segundos se puede instalar, compartir y usar como una app. Del iPhone al escritorio, es el mismo resultado generado.',
     'hero.urlPlaceholder': 'Introduce el enlace del sitio web',
@@ -1169,9 +1151,6 @@
     'nav.langLabel': 'Idioma',
     'nav.github': 'Ver o código no GitHub',
 
-    'hero.kicker': 'WEBTOAPP / DO SITE AO APP',
-    'hero.titleLine1': 'Transforme sites',
-    'hero.titleLine2': 'em aplicativos.',
     'hero.badge': 'Código aberto · Grátis · Sem cadastro',
     'hero.subtitle': 'Insira um link. Em segundos ele pode ser instalado, compartilhado e usado como um app. Do iPhone ao desktop, é o mesmo resultado gerado.',
     'hero.urlPlaceholder': 'Insira o link do site',
@@ -1351,9 +1330,6 @@
     'nav.langLabel': 'Langue',
     'nav.github': 'Voir le code sur GitHub',
 
-    'hero.kicker': 'WEBTOAPP / DU SITE À L\u2019APPLI',
-    'hero.titleLine1': 'Transformez les sites web',
-    'hero.titleLine2': 'en applications.',
     'hero.badge': 'Open source · Gratuit · Sans inscription',
     'hero.subtitle': 'Saisissez un lien. En quelques secondes, il peut être installé, partagé et utilisé comme une application. De l\u2019iPhone au bureau, c\u2019est le même résultat généré.',
     'hero.urlPlaceholder': 'Saisissez le lien du site web',
@@ -1533,9 +1509,6 @@
     'nav.langLabel': 'Sprache',
     'nav.github': 'Quellcode auf GitHub ansehen',
 
-    'hero.kicker': 'WEBTOAPP / VON DER WEBSITE ZUR APP',
-    'hero.titleLine1': 'Websites in',
-    'hero.titleLine2': 'Apps verwandeln.',
     'hero.badge': 'Open Source · Kostenlos · Ohne Anmeldung',
     'hero.subtitle': 'Gib einen Link ein. Sekunden später lässt er sich installieren, teilen und wie eine App nutzen. Vom iPhone bis zum Desktop – dasselbe generierte Ergebnis.',
     'hero.urlPlaceholder': 'Website-Link eingeben',


### PR DESCRIPTION
Fixes #51

## Summary

- Remove the giant serif hero headline (".hero-copy": kicker + h1) that occupied the whole left column on landscape and a huge vertical block on portrait, blocking the view and pushing the input card aside/below the fold
- `.hero-grid` collapses from two columns to a single centered 640px column, so the URL-input card is the sole focus of the first screen on all viewports
- Delete now-unused CSS (`#hero h1`, `.hero-copy`, `.hero-kicker`, `.gradient-text`, plus their 1100px/720px media-query and RTL references) and the unused `hero.kicker` / `hero.titleLine1` / `hero.titleLine2` i18n keys in all 9 languages
- Bump `?v=` cache-busting strings in index.html

## Test plan

- `pytest tests/` — 247 passed locally
- Visual check on local server (uvicorn): landscape 1600x1000 and portrait 500x950 both render the centered card with no overflow and no leftover headline; nav, stats and history sections unchanged