### PR TITLE
feat(design): restraint pass — flat surfaces, tighter radii, coral accent, serif headline

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7,20 +7,18 @@
   --ink-faint: rgba(30, 25, 20, 0.46);
   --line: rgba(30, 25, 20, 0.1);
   --line-strong: rgba(30, 25, 20, 0.16);
-  --accent: #2a211b;
-  --accent-soft: #d4b292;
-  --accent-warm: #b47e57;
+  --accent: #c97953;
+  --accent-warm: #a85c3a;
   --success: #4f715a;
   --danger: #a0533d;
   --surface: rgba(255, 252, 247, 0.76);
   --surface-strong: rgba(255, 253, 249, 0.9);
-  --shadow: 0 18px 50px rgba(75, 55, 35, 0.08);
-  --radius-sm: 10px;
-  --radius-md: 14px;
-  --radius-lg: 20px;
-  --radius-xl: 28px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
   --font-sans: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-serif: "Noto Serif SC", "Songti SC", "STSong", serif;
+  --font-serif: "Spectral", "Noto Serif SC", "Songti SC", "STSong", serif;
   --transition: 180ms ease;
 }
 
@@ -41,10 +39,7 @@ body {
   min-height: 100vh;
   overflow-x: hidden;
   color: var(--ink);
-  background:
-    radial-gradient(circle at top right, rgba(212, 178, 146, 0.12), transparent 26%),
-    radial-gradient(circle at bottom left, rgba(180, 126, 87, 0.08), transparent 24%),
-    linear-gradient(180deg, #faf6ef 0%, #f4ede2 100%);
+  background: var(--paper);
   font-family: var(--font-sans);
   line-height: 1.5;
 }
@@ -68,16 +63,13 @@ button {
   cursor: pointer;
 }
 
-::selection {
-  background: rgba(180, 126, 87, 0.2);
+:is(a, button, input, select, summary, [tabindex]):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
-#bg {
-  position: fixed;
-  inset: 0;
-  z-index: 0;
-  opacity: 0.014;
-  pointer-events: none;
+::selection {
+  background: rgba(201, 121, 83, 0.22);
 }
 
 #nav {
@@ -88,9 +80,8 @@ button {
   align-items: center;
   justify-content: space-between;
   padding: 18px clamp(22px, 4vw, 52px);
-  background: rgba(247, 243, 236, 0.88);
+  background: var(--paper);
   border-bottom: 1px solid rgba(30, 25, 20, 0.08);
-  backdrop-filter: blur(16px);
 }
 
 .logo {
@@ -133,37 +124,49 @@ section {
   display: grid;
   grid-template-columns: minmax(0, 640px);
   justify-content: center;
+  row-gap: clamp(28px, 5vh, 48px);
+}
+
+.hero-copy {
+  max-width: 46rem;
+  text-align: center;
+}
+
+.hero-kicker {
+  margin-bottom: 14px;
+  color: var(--ink-faint);
+  font-size: 0.74rem;
+  letter-spacing: 0.16em;
+}
+
+#hero h1 {
+  font-family: var(--font-serif);
+  font-size: clamp(2.4rem, 5vw, 3.8rem);
+  line-height: 1.08;
+  letter-spacing: 0;
+  font-weight: 600;
+  color: var(--ink);
 }
 
 .hero-side {
+  width: 100%;
   padding: 24px 28px 24px;
   border: 1px solid var(--line);
   border-radius: var(--radius-xl);
-  background: rgba(255, 252, 247, 0.68);
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(12px);
+  background: var(--paper-strong);
 }
 
 .badge {
   display: inline-flex;
   align-items: center;
   margin-bottom: 14px;
-  padding: 10px 16px;
+  padding: 8px 12px;
   border: 1px solid rgba(30, 25, 20, 0.1);
-  border-radius: 999px;
+  border-radius: 6px;
   background: rgba(255, 255, 255, 0.42);
   color: rgba(30, 25, 20, 0.76);
   font-size: 0.84rem;
   font-weight: 600;
-}
-
-.hero-body {
-  max-width: 14em;
-  font-family: var(--font-serif);
-  font-size: clamp(1.7rem, 2.2vw, 2.3rem);
-  line-height: 1.42;
-  letter-spacing: 0;
-  color: rgba(30, 25, 20, 0.94);
 }
 
 .subtitle {
@@ -181,7 +184,7 @@ section {
   margin-top: 32px;
   padding: 8px;
   border: 1px solid rgba(30, 25, 20, 0.12);
-  border-radius: 18px;
+  border-radius: 12px;
   background: rgba(255, 255, 255, 0.5);
 }
 
@@ -189,7 +192,7 @@ section {
   min-width: 0;
   width: 100%;
   padding: 16px 18px;
-  border-radius: 14px;
+  border-radius: 10px;
   background: rgba(248, 243, 236, 0.84);
   color: var(--ink);
   font-size: 0.98rem;
@@ -204,16 +207,15 @@ section {
   align-items: center;
   gap: 10px;
   padding: 0 22px;
-  border-radius: 14px;
-  background: #2b221c;
+  border-radius: 10px;
+  background: var(--ink);
   color: #fffaf4;
   font-weight: 650;
-  transition: transform var(--transition), filter var(--transition), background var(--transition);
+  transition: background var(--transition);
 }
 
 #distill-btn:hover {
-  transform: translateY(-1px);
-  filter: brightness(1.03);
+  background: #2e2620;
 }
 
 .stats {
@@ -279,10 +281,8 @@ section {
 .panel {
   overflow: hidden;
   border: 1px solid rgba(30, 25, 20, 0.08);
-  border-radius: 24px;
-  background: rgba(255, 252, 247, 0.7);
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(12px);
+  border-radius: 16px;
+  background: var(--paper-strong);
 }
 
 .panel-head {
@@ -307,9 +307,9 @@ section {
 
 .status-badge {
   padding: 6px 11px;
-  border-radius: 999px;
-  background: rgba(180, 126, 87, 0.14);
-  color: #966342;
+  border-radius: 6px;
+  background: rgba(201, 121, 83, 0.14);
+  color: #8a4b2d;
   font-size: 0.77rem;
   font-weight: 700;
 }
@@ -339,7 +339,7 @@ section {
   width: 30%;
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, rgba(180, 126, 87, 0) 0%, rgba(180, 126, 87, 0.72) 50%, rgba(180, 126, 87, 0) 100%);
+  background: linear-gradient(90deg, rgba(201, 121, 83, 0) 0%, rgba(201, 121, 83, 0.72) 50%, rgba(201, 121, 83, 0) 100%);
   animation: load-slide 1.5s ease infinite;
 }
 
@@ -438,7 +438,7 @@ section {
   width: 100%;
   padding: 14px 16px;
   border: 1px solid rgba(30, 25, 20, 0.1);
-  border-radius: 14px;
+  border-radius: 10px;
   background: rgba(250, 246, 240, 0.94);
   font-size: 1rem;
   transition: border-color var(--transition), background var(--transition);
@@ -448,7 +448,7 @@ section {
 .field input[type="number"]:focus,
 .field select:focus,
 .icon-upload-meta input[type="file"]:focus {
-  border-color: rgba(180, 126, 87, 0.42);
+  border-color: rgba(201, 121, 83, 0.5);
   background: rgba(255, 252, 246, 1);
 }
 
@@ -481,7 +481,7 @@ section {
   min-height: 54px;
   padding: 10px 14px;
   border: 1px solid rgba(30, 25, 20, 0.1);
-  border-radius: 14px;
+  border-radius: 10px;
   background: rgba(250, 246, 240, 0.94);
 }
 
@@ -492,19 +492,18 @@ section {
   min-height: 36px;
   padding: 0 14px;
   border: 1px solid rgba(30, 25, 20, 0.18);
-  border-radius: 10px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.9);
   color: var(--ink);
   font-size: 0.88rem;
   font-weight: 600;
   white-space: nowrap;
   cursor: pointer;
-  transition: background var(--transition), transform var(--transition);
+  transition: background var(--transition);
 }
 
 .file-picker-btn:hover {
   background: rgba(255, 255, 255, 1);
-  transform: translateY(-1px);
 }
 
 .file-picker-name {
@@ -520,7 +519,7 @@ section {
   position: relative;
   width: 96px;
   height: 96px;
-  border-radius: 20px;
+  border-radius: 14px;
   overflow: hidden;
   background: rgba(250, 246, 240, 0.96);
   border: 1px solid rgba(30, 25, 20, 0.1);
@@ -566,17 +565,16 @@ section {
   min-height: 40px;
   padding: 0 16px;
   border: 1px solid rgba(30, 25, 20, 0.1);
-  border-radius: 999px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.42);
   color: var(--ink-soft);
   font-size: 0.85rem;
   font-weight: 600;
-  transition: background var(--transition), transform var(--transition);
+  transition: background var(--transition);
 }
 
 .icon-upload-clear:hover {
   background: rgba(255, 255, 255, 0.74);
-  transform: translateY(-1px);
 }
 
 .icon-upload-clear:disabled {
@@ -589,14 +587,14 @@ section {
 .advanced-panel {
   margin-bottom: 24px;
   border: 1px solid rgba(30, 25, 20, 0.08);
-  border-radius: 18px;
+  border-radius: 12px;
   background: rgba(251, 248, 243, 0.68);
 }
 
 .feature-panel {
   margin-bottom: 18px;
   border: 1px solid rgba(30, 25, 20, 0.08);
-  border-radius: 18px;
+  border-radius: 12px;
   background: rgba(252, 249, 244, 0.8);
 }
 
@@ -665,7 +663,7 @@ section {
   gap: 18px;
   padding: 18px;
   border: 1px solid rgba(30, 25, 20, 0.08);
-  border-radius: 16px;
+  border-radius: 12px;
   background: rgba(255, 255, 255, 0.46);
 }
 
@@ -704,8 +702,8 @@ section {
   justify-content: center;
   min-height: 22px;
   padding: 0 8px;
-  border-radius: 999px;
-  background: rgba(180, 126, 87, 0.12);
+  border-radius: 6px;
+  background: rgba(201, 121, 83, 0.12);
   color: var(--accent-warm);
   font-size: 0.73rem;
   font-weight: 700;
@@ -749,7 +747,7 @@ section {
 }
 
 .switch input:checked + .switch-ui {
-  background: rgba(180, 126, 87, 0.8);
+  background: rgba(201, 121, 83, 0.85);
 }
 
 .switch input:checked + .switch-ui::after {
@@ -787,7 +785,7 @@ section {
   width: 100%;
   padding: 0 14px;
   border: 1px solid rgba(30, 25, 20, 0.1);
-  border-radius: 12px;
+  border-radius: 8px;
   background: rgba(250, 246, 240, 0.94);
   color: rgba(30, 25, 20, 0.62);
   font-size: 0.88rem;
@@ -797,8 +795,8 @@ section {
 }
 
 .segmented-option input:checked + span {
-  border-color: rgba(180, 126, 87, 0.34);
-  background: rgba(180, 126, 87, 0.12);
+  border-color: rgba(201, 121, 83, 0.4);
+  background: rgba(201, 121, 83, 0.12);
   color: var(--ink);
 }
 
@@ -874,7 +872,7 @@ section {
   gap: 12px;
   padding: 10px 12px;
   border: 1px solid rgba(30, 25, 20, 0.07);
-  border-radius: 14px;
+  border-radius: 10px;
   background: rgba(255, 255, 255, 0.42);
 }
 
@@ -902,7 +900,7 @@ section {
   width: 38px;
   height: 38px;
   flex-shrink: 0;
-  border-radius: 12px;
+  border-radius: 10px;
   border: 1px solid rgba(30, 25, 20, 0.08);
   background: rgba(255, 255, 255, 0.66);
 }
@@ -927,7 +925,7 @@ section {
 .platform-config {
   margin-bottom: 24px;
   border: 1px solid rgba(30, 25, 20, 0.08);
-  border-radius: 18px;
+  border-radius: 12px;
   background: rgba(252, 249, 244, 0.8);
 }
 
@@ -973,7 +971,7 @@ section {
   min-height: 42px;
   padding: 0 16px 0 12px;
   border: 1px solid rgba(30, 25, 20, 0.1);
-  border-radius: 999px;
+  border-radius: 8px;
   background: rgba(250, 246, 240, 0.94);
   color: rgba(30, 25, 20, 0.62);
   font-size: 0.88rem;
@@ -1001,13 +999,13 @@ section {
 }
 
 .platform-tab.active {
-  border-color: rgba(180, 126, 87, 0.4);
-  background: rgba(180, 126, 87, 0.14);
+  border-color: rgba(201, 121, 83, 0.45);
+  background: rgba(201, 121, 83, 0.13);
   color: var(--ink);
 }
 
 .platform-tab:focus-visible {
-  outline: 2px solid var(--accent-warm);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -1079,7 +1077,7 @@ section {
   gap: 10px;
   padding: 18px;
   border: 1px solid rgba(30, 25, 20, 0.08);
-  border-radius: 16px;
+  border-radius: 12px;
   background: rgba(255, 255, 255, 0.46);
 }
 
@@ -1109,7 +1107,7 @@ section {
   height: 56px;
   flex-shrink: 0;
   border: 1px solid rgba(30, 25, 20, 0.12);
-  border-radius: 14px;
+  border-radius: 10px;
   background: none;
 }
 
@@ -1124,16 +1122,15 @@ section {
 .btn-primary {
   width: 100%;
   padding: 15px 16px;
-  border-radius: 16px;
-  background: #241d18;
+  border-radius: 10px;
+  background: var(--ink);
   color: #fffaf5;
   font-weight: 650;
-  transition: transform var(--transition), filter var(--transition);
+  transition: background var(--transition);
 }
 
 .btn-primary:hover {
-  transform: translateY(-1px);
-  filter: brightness(1.03);
+  background: #2e2620;
 }
 
 .create-note {
@@ -1197,16 +1194,15 @@ section {
   min-height: 42px;
   padding: 0 16px;
   border: 1px solid rgba(30, 25, 20, 0.1);
-  border-radius: 999px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.5);
   color: var(--ink);
   font-size: 0.88rem;
   font-weight: 600;
-  transition: transform var(--transition), background var(--transition);
+  transition: background var(--transition);
 }
 
 .btn-secondary:hover {
-  transform: translateY(-1px);
   background: rgba(255, 255, 255, 0.86);
 }
 
@@ -1241,7 +1237,7 @@ section {
   gap: 18px;
   padding: 20px 22px;
   border: 1px solid rgba(30, 25, 20, 0.08);
-  border-radius: 22px;
+  border-radius: 14px;
   background: rgba(255, 252, 247, 0.64);
 }
 
@@ -1260,7 +1256,7 @@ section {
   width: 42px;
   height: 42px;
   flex-shrink: 0;
-  border-radius: 12px;
+  border-radius: 10px;
   border: 1px solid rgba(30, 25, 20, 0.08);
   background: rgba(255, 255, 255, 0.6);
   object-fit: cover;
@@ -1308,7 +1304,7 @@ section {
   min-height: 42px;
   padding: 0 14px;
   border: 1px solid rgba(30, 25, 20, 0.06);
-  border-radius: 14px;
+  border-radius: 10px;
   background: rgba(255, 255, 255, 0.36);
   color: rgba(30, 25, 20, 0.58);
   font-size: 0.82rem;
@@ -1332,7 +1328,7 @@ section {
   min-height: 34px;
   padding: 0 12px;
   border: 1px solid rgba(30, 25, 20, 0.08);
-  border-radius: 999px;
+  border-radius: 6px;
   background: rgba(255, 255, 255, 0.46);
   color: rgba(30, 25, 20, 0.62);
   font-size: 0.8rem;
@@ -1355,23 +1351,22 @@ section {
   min-height: 40px;
   padding: 0 14px;
   border: 1px solid rgba(30, 25, 20, 0.1);
-  border-radius: 12px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.54);
   color: var(--ink);
   font-size: 0.86rem;
   font-weight: 600;
   text-decoration: none;
-  transition: transform var(--transition), background var(--transition);
+  transition: background var(--transition);
 }
 
 .history-action:hover {
-  transform: translateY(-1px);
   background: rgba(255, 255, 255, 0.9);
 }
 
 .history-action.primary {
-  background: #241d18;
-  border-color: #241d18;
+  background: var(--ink);
+  border-color: var(--ink);
   color: #fffaf5;
 }
 
@@ -1417,7 +1412,7 @@ section {
   margin: 0 0 20px;
   overflow: hidden;
   border: 1px solid rgba(30, 25, 20, 0.1);
-  border-radius: 18px;
+  border-radius: 12px;
   background: rgba(255, 252, 247, 0.86);
 }
 
@@ -1431,7 +1426,7 @@ section {
 
 #copy-btn {
   padding: 0 18px;
-  background: rgba(36, 29, 24, 0.96);
+  background: var(--ink);
   color: #fffaf4;
   font-weight: 650;
 }
@@ -1446,7 +1441,7 @@ section {
 .platform-tag {
   padding: 7px 14px;
   border: 1px solid rgba(30, 25, 20, 0.08);
-  border-radius: 999px;
+  border-radius: 6px;
   background: rgba(255, 252, 247, 0.56);
   color: var(--ink-soft);
   font-size: 0.82rem;
@@ -1455,7 +1450,7 @@ section {
 .preview-shell {
   overflow: hidden;
   border: 1px solid rgba(30, 25, 20, 0.08);
-  border-radius: 22px;
+  border-radius: 14px;
   background: rgba(255, 252, 247, 0.92);
 }
 
@@ -1490,7 +1485,7 @@ section {
   padding: 10px 13px;
   overflow: hidden;
   border: 1px solid rgba(30, 25, 20, 0.08);
-  border-radius: 999px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.54);
   color: var(--ink-faint);
   text-align: left;
@@ -1508,15 +1503,14 @@ section {
   height: 40px;
   padding: 0 14px;
   border: 1px solid rgba(30, 25, 20, 0.1);
-  border-radius: 999px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.48);
   color: var(--ink);
   font-weight: 600;
-  transition: transform var(--transition), background var(--transition);
+  transition: background var(--transition);
 }
 
 .preview-open-btn:hover {
-  transform: translateY(-1px);
   background: rgba(255, 255, 255, 0.84);
 }
 
@@ -1577,11 +1571,10 @@ section {
 
   .hero-side {
     padding: 22px 18px 20px;
-    border-radius: 22px;
   }
 
-  .hero-body {
-    font-size: 1.35rem;
+  #hero h1 {
+    font-size: clamp(2rem, 9vw, 2.6rem);
   }
 
   .url-input-wrap {
@@ -1622,7 +1615,7 @@ section {
   .icon-upload-preview {
     width: 84px;
     height: 84px;
-    border-radius: 18px;
+    border-radius: 12px;
   }
 
   .feature-panel summary {
@@ -1762,7 +1755,7 @@ section {
   background-repeat: no-repeat;
   background-position: right 12px center;
   border: 1px solid rgba(30, 25, 20, 0.16);
-  border-radius: 999px;
+  border-radius: 8px;
   padding: 8px 34px 8px 14px;
   cursor: pointer;
   transition: border-color 0.18s ease, background-color 0.18s ease;
@@ -1783,6 +1776,7 @@ section {
   padding: 8px 14px 8px 34px;
 }
 
+[dir="rtl"] .hero-kicker,
 [dir="rtl"] .history-kicker {
   letter-spacing: 0;
 }
@@ -1805,7 +1799,7 @@ section {
   display: inline-flex;
   padding: 4px;
   border: 1px solid var(--line);
-  border-radius: 999px;
+  border-radius: 10px;
   background: var(--surface);
   gap: 4px;
   margin-bottom: 14px;
@@ -1814,7 +1808,7 @@ section {
 .mode-btn {
   appearance: none;
   border: 0;
-  border-radius: 999px;
+  border-radius: 8px;
   padding: 8px 16px;
   font: inherit;
   font-size: .88rem;
@@ -1882,7 +1876,7 @@ section {
   height: 20px;
   margin-inline-start: 8px;
   padding: 0 8px;
-  border-radius: 999px;
+  border-radius: 6px;
   background: rgba(79, 113, 90, 0.14);
   color: var(--success);
   font-size: .68rem;

--- a/index.html
+++ b/index.html
@@ -13,14 +13,12 @@
   <link rel="icon" href="assets/site-logo.jpg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif+SC:wght@400;500;600;700;900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css?v=20260908-hero1">
-  <script src="js/i18n.js?v=20260908-hero1"></script>
-  <script src="js/i18n.strings.js?v=20260908-hero1"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif+SC:wght@400;500;600;700;900&family=Spectral:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css?v=20260908-design1">
+  <script src="js/i18n.js?v=20260908-design1"></script>
+  <script src="js/i18n.strings.js?v=20260908-design1"></script>
 </head>
 <body>
-  <canvas id="bg"></canvas>
-
   <header id="nav">
     <a class="logo" href="/">
       <img src="assets/site-logo.jpg" alt="WebToApp">
@@ -44,6 +42,10 @@
     <!-- ===== HERO ===== -->
     <section id="hero">
       <div class="hero-grid">
+        <div class="hero-copy" data-reveal>
+          <p class="hero-kicker" data-i18n="hero.kicker">WEBTOAPP / WEBSITE TO APP</p>
+          <h1><span data-i18n="hero.titleLine1">Turn websites</span><br><span data-i18n="hero.titleLine2">into apps.</span></h1>
+        </div>
         <div class="hero-side" data-reveal>
           <div class="badge" data-i18n="hero.badge">Open source · Free · No sign-up</div>
           <p class="subtitle" data-i18n="hero.subtitle">Enter a link. Seconds later it can be installed, shared and used like an app. From iPhone to desktop, it is the same generated result.</p>
@@ -395,6 +397,6 @@
 
   </main>
 
-  <script src="js/app.v5.js?v=20260908-hero1"></script>
+  <script src="js/app.v5.js?v=20260908-design1"></script>
 </body>
 </html>

--- a/js/app.v5.js
+++ b/js/app.v5.js
@@ -6,48 +6,6 @@
 (function () {
   'use strict';
 
-  // --- Particle System ---
-  const canvas = document.getElementById('bg');
-  const ctx = canvas.getContext('2d');
-  let particles = [];
-  const PARTICLE_COUNT = 10;
-
-  function resize() {
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
-  }
-
-  function initParticles() {
-    particles = Array.from({ length: PARTICLE_COUNT }, () => ({
-      x: Math.random() * canvas.width,
-      y: Math.random() * canvas.height,
-      vx: (Math.random() - 0.5) * 0.14,
-      vy: (Math.random() - 0.5) * 0.14,
-      r: Math.random() * 2.2 + 1.2,
-      a: Math.random() * 0.18 + 0.05,
-    }));
-  }
-
-  function drawParticles() {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    for (let i = 0; i < particles.length; i++) {
-      const p = particles[i];
-      p.x += p.vx; p.y += p.vy;
-      if (p.x < 0 || p.x > canvas.width) p.vx *= -1;
-      if (p.y < 0 || p.y > canvas.height) p.vy *= -1;
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
-      ctx.fillStyle = `rgba(176,130,96,${p.a})`;
-      ctx.fill();
-    }
-    requestAnimationFrame(drawParticles);
-  }
-
-  resize();
-  initParticles();
-  drawParticles();
-  window.addEventListener('resize', () => { resize(); initParticles(); });
-
   // --- Scroll Reveal ---
   const revealObserver = new IntersectionObserver((entries) => {
     entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('revealed'); revealObserver.unobserve(e.target); } });

--- a/js/i18n.strings.js
+++ b/js/i18n.strings.js
@@ -29,6 +29,9 @@
     'nav.langLabel': 'Language',
     'nav.github': 'View source on GitHub',
 
+    'hero.kicker': 'WEBTOAPP / WEBSITE TO APP',
+    'hero.titleLine1': 'Turn websites',
+    'hero.titleLine2': 'into apps.',
     'hero.badge': 'Open source · Free · No sign-up',
     'hero.subtitle': 'Enter a link. Seconds later it can be installed, shared and used like an app. From iPhone to desktop, it is the same generated result.',
     'hero.urlPlaceholder': 'Enter a website link',
@@ -232,6 +235,9 @@
     'nav.langLabel': '语言',
     'nav.github': '在 GitHub 上查看源码',
 
+    'hero.kicker': 'WEBTOAPP / 网站到应用',
+    'hero.titleLine1': '把网站',
+    'hero.titleLine2': '做成应用。',
     'hero.badge': '开源 · 免费 · 无需登录',
     'hero.subtitle': '输入一个链接。几秒钟后，它就能被安装、被分享，也能像应用一样被使用。从 iPhone 到桌面端，用的是同一套生成结果。',
     'hero.urlPlaceholder': '输入网站链接',
@@ -435,6 +441,9 @@
     'nav.langLabel': '言語',
     'nav.github': 'GitHub でソースを見る',
 
+    'hero.kicker': 'WEBTOAPP / ウェブからアプリへ',
+    'hero.titleLine1': 'ウェブサイトを',
+    'hero.titleLine2': 'アプリに。',
     'hero.badge': 'オープンソース · 無料 · 登録不要',
     'hero.subtitle': 'リンクを入力するだけ。数秒後にはインストール・共有でき、アプリのように使えます。iPhone からデスクトップまで、同じ生成結果が使えます。',
     'hero.urlPlaceholder': 'ウェブサイトのリンクを入力',
@@ -614,6 +623,9 @@
     'nav.langLabel': 'اللغة',
     'nav.github': 'عرض المصدر على GitHub',
 
+    'hero.kicker': 'WEBTOAPP / من الموقع إلى التطبيق',
+    'hero.titleLine1': 'حوّل المواقع',
+    'hero.titleLine2': 'إلى تطبيقات.',
     'hero.badge': 'مفتوح المصدر · مجاني · بدون تسجيل',
     'hero.subtitle': 'أدخل رابطًا. خلال ثوانٍ يمكن تثبيته ومشاركته واستخدامه كتطبيق. من iPhone إلى سطح المكتب، النتيجة المُولّدة واحدة.',
     'hero.urlPlaceholder': 'أدخل رابط الموقع',
@@ -793,6 +805,9 @@
     'nav.langLabel': 'Язык',
     'nav.github': 'Открыть исходный код на GitHub',
 
+    'hero.kicker': 'WEBTOAPP / САЙТ В ПРИЛОЖЕНИЕ',
+    'hero.titleLine1': 'Превратите сайты',
+    'hero.titleLine2': 'в приложения.',
     'hero.badge': 'Открытый код · Бесплатно · Без регистрации',
     'hero.subtitle': 'Введите ссылку. Через несколько секунд её можно установить, отправить и использовать как приложение. От iPhone до десктопа — один и тот же результат.',
     'hero.urlPlaceholder': 'Введите ссылку на сайт',
@@ -972,6 +987,9 @@
     'nav.langLabel': 'Idioma',
     'nav.github': 'Ver el código en GitHub',
 
+    'hero.kicker': 'WEBTOAPP / DEL SITIO A LA APP',
+    'hero.titleLine1': 'Convierte sitios web',
+    'hero.titleLine2': 'en aplicaciones.',
     'hero.badge': 'Código abierto · Gratis · Sin registro',
     'hero.subtitle': 'Introduce un enlace. En segundos se puede instalar, compartir y usar como una app. Del iPhone al escritorio, es el mismo resultado generado.',
     'hero.urlPlaceholder': 'Introduce el enlace del sitio web',
@@ -1151,6 +1169,9 @@
     'nav.langLabel': 'Idioma',
     'nav.github': 'Ver o código no GitHub',
 
+    'hero.kicker': 'WEBTOAPP / DO SITE AO APP',
+    'hero.titleLine1': 'Transforme sites',
+    'hero.titleLine2': 'em aplicativos.',
     'hero.badge': 'Código aberto · Grátis · Sem cadastro',
     'hero.subtitle': 'Insira um link. Em segundos ele pode ser instalado, compartilhado e usado como um app. Do iPhone ao desktop, é o mesmo resultado gerado.',
     'hero.urlPlaceholder': 'Insira o link do site',
@@ -1330,6 +1351,9 @@
     'nav.langLabel': 'Langue',
     'nav.github': 'Voir le code sur GitHub',
 
+    'hero.kicker': 'WEBTOAPP / DU SITE À L\u2019APPLI',
+    'hero.titleLine1': 'Transformez les sites web',
+    'hero.titleLine2': 'en applications.',
     'hero.badge': 'Open source · Gratuit · Sans inscription',
     'hero.subtitle': 'Saisissez un lien. En quelques secondes, il peut être installé, partagé et utilisé comme une application. De l\u2019iPhone au bureau, c\u2019est le même résultat généré.',
     'hero.urlPlaceholder': 'Saisissez le lien du site web',
@@ -1509,6 +1533,9 @@
     'nav.langLabel': 'Sprache',
     'nav.github': 'Quellcode auf GitHub ansehen',
 
+    'hero.kicker': 'WEBTOAPP / VON DER WEBSITE ZUR APP',
+    'hero.titleLine1': 'Websites in',
+    'hero.titleLine2': 'Apps verwandeln.',
     'hero.badge': 'Open Source · Kostenlos · Ohne Anmeldung',
     'hero.subtitle': 'Gib einen Link ein. Sekunden später lässt er sich installieren, teilen und wie eine App nutzen. Vom iPhone bis zum Desktop – dasselbe generierte Ergebnis.',
     'hero.urlPlaceholder': 'Website-Link eingeben',


### PR DESCRIPTION
Fixes #53

## Summary

- **Flatten backgrounds**: body 3-layer gradient + particle canvas replaced with a single flat `var(--paper)`; removed `<canvas id="bg">` and its JS particle system entirely.
- **Flatten surfaces**: removed `backdrop-filter` blur and `box-shadow` from `#nav`, `.hero-side`, `.panel`; cards are now solid `var(--paper-strong)` with hairline 1px borders.
- **Tighter radii**: `--radius-*` scale reduced to 6/8/12/16px; pill-style (999px) buttons/chips converted to small rounded rects.
- **Coral accent**: `--accent` changed from dark ink to coral `#c97953`; all warm-tan `rgba(180,126,87,*)` interactive states replaced with coral equivalents; `--accent-warm` deepened to `#a85c3a` for text-level use.
- **Unified dark buttons**: `#distill-btn`, `.btn-primary`, `#copy-btn`, `.history-action.primary` all use `var(--ink)`; hover lifts removed.
- **Global focus visibility**: added `:focus-visible` outline rule — 11 interactive components previously had no focus indication (a11y fix).
- **Serif headline restored**: `.hero-copy` (kicker + h1) returns above the centered card at a restrained size; Spectral font added for Latin editorial serif; all 9 languages restored from git history.

## Test plan

- `node --check` passes on `app.v5.js`, `i18n.strings.js`, `i18n.js`
- `pytest tests/` — 247 passed locally
- Headless Chrome screenshots verified: landscape 1600×1000, portrait 500×950, Arabic RTL 1600×1000
- No console errors; all 9 languages render the restored headline correctly
