### PR TITLE
fix(history): bulk delete in one request; drop cross-user recover endpoint

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1221,10 +1221,6 @@ section {
   margin: 0;
 }
 
-.history-recover-btn {
-  margin-top: 14px;
-}
-
 .history-list {
   display: flex;
   flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif+SC:wght@400;500;600;700;900&family=Spectral:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css?v=20260909-hist1">
-  <script src="js/i18n.js?v=20260909-hist1"></script>
-  <script src="js/i18n.strings.js?v=20260909-hist1"></script>
+  <link rel="stylesheet" href="css/style.css?v=20260909-hist2">
+  <script src="js/i18n.js?v=20260909-hist2"></script>
+  <script src="js/i18n.strings.js?v=20260909-hist2"></script>
 </head>
 <body>
   <header id="nav">
@@ -389,7 +389,6 @@
         <div class="history-body">
           <div id="history-empty" class="history-empty">
             <p data-i18n="history.empty">No build history on this device yet. Generate an app first, or import a record exported from another device.</p>
-            <button id="history-recover-btn" class="btn-secondary history-recover-btn" type="button" data-i18n="history.recover">Recover existing builds</button>
           </div>
           <div id="history-select-bar" class="history-select-bar hidden">
             <label class="history-select-all">
@@ -409,6 +408,6 @@
 
   </main>
 
-  <script src="js/app.v5.js?v=20260909-hist1"></script>
+  <script src="js/app.v5.js?v=20260909-hist2"></script>
 </body>
 </html>

--- a/js/app.v5.js
+++ b/js/app.v5.js
@@ -100,7 +100,6 @@
   const previewOpenBtn = document.getElementById('preview-open-btn');
   const historyList = document.getElementById('history-list');
   const historyEmpty = document.getElementById('history-empty');
-  const historyRecoverBtn = document.getElementById('history-recover-btn');
   const historyExportBtn = document.getElementById('history-export-btn');
   const historyImportBtn = document.getElementById('history-import-btn');
   const historyImportInput = document.getElementById('history-import-input');
@@ -369,15 +368,6 @@
       headers: apiHeaders(),
     });
     if (!res.ok) throw new Error('attach failed');
-    return res.json();
-  }
-
-  async function recoverHistoryItems() {
-    const res = await fetch('/api/history/recover', {
-      method: 'POST',
-      headers: apiHeaders(),
-    });
-    if (!res.ok) throw new Error('recover failed');
     return res.json();
   }
 
@@ -1277,10 +1267,12 @@
     if (!window.confirm(t('history.confirmDeleteBulk', { n: String(ids.length) }))) return;
     try {
       historyDeleteSelectedBtn.disabled = true;
-      await Promise.all(ids.map((id) => fetch(`/api/history/${encodeURIComponent(id)}`, {
-        method: 'DELETE',
-        headers: { 'X-Device-Fingerprint': deviceFingerprint },
-      })));
+      const res = await fetch('/api/history/delete-bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Device-Fingerprint': deviceFingerprint },
+        body: JSON.stringify({ app_ids: ids }),
+      });
+      if (!res.ok) throw new Error('bulk delete failed');
       setHistorySelectMode(false);
       await loadHistory();
     } catch (_err) {
@@ -1334,23 +1326,6 @@
       historyImportInput.value = '';
     }
   });
-
-  if (historyRecoverBtn) {
-    historyRecoverBtn.addEventListener('click', async () => {
-      const original = historyRecoverBtn.textContent;
-      historyRecoverBtn.disabled = true;
-      historyRecoverBtn.textContent = t('history.recovering');
-      try {
-        const data = await recoverHistoryItems();
-        renderHistory((data.history && data.history.items) || []);
-      } catch (_err) {
-        alert(t('err.recoverRetry'));
-      } finally {
-        historyRecoverBtn.disabled = false;
-        historyRecoverBtn.textContent = original;
-      }
-    });
-  }
 
   // --- Recipe Cards ---
   document.querySelectorAll('.recipe-card').forEach(card => {

--- a/js/i18n.strings.js
+++ b/js/i18n.strings.js
@@ -151,8 +151,6 @@
     'history.export': 'Export history',
     'history.import': 'Import history',
     'history.empty': 'No build history on this device yet. Generate an app first, or import a record exported from another device.',
-    'history.recover': 'Recover existing builds',
-    'history.recovering': 'Recovering...',
     'history.justNow': 'Just now',
     'history.visits': 'Visits {n}',
     'history.downloads': 'Downloads {n}',
@@ -214,7 +212,6 @@
     'err.exportRetry': 'Export failed, please retry',
     'err.importFormat': 'Import failed, please check the file format',
     'err.removeRetry': 'Remove failed, please retry',
-    'err.recoverRetry': 'Recover failed, please retry'
   });
 
   // ---------- 简体中文 ----------
@@ -361,8 +358,6 @@
     'history.export': '导出历史',
     'history.import': '导入历史',
     'history.empty': '当前设备还没有历史构建。先生成一个应用，或者导入另一台设备导出的记录。',
-    'history.recover': '恢复已有构建',
-    'history.recovering': '恢复中...',
     'history.justNow': '刚刚',
     'history.visits': '访问 {n} 次',
     'history.downloads': '下载 {n} 次',
@@ -424,7 +419,6 @@
     'err.exportRetry': '导出失败，请重试',
     'err.importFormat': '导入失败，请确认文件格式正确',
     'err.removeRetry': '移除失败，请重试',
-    'err.recoverRetry': '恢复失败，请重试'
   });
 
   // ---------- 日本語 ----------
@@ -547,8 +541,6 @@
     'history.export': '履歴をエクスポート',
     'history.import': '履歴をインポート',
     'history.empty': 'このデバイスにはまだビルド履歴がありません。まずアプリを生成するか、別のデバイスからエクスポートした記録をインポートしてください。',
-    'history.recover': '既存のビルドを復元',
-    'history.recovering': '復元中...',
     'history.justNow': 'たった今',
     'history.visits': 'アクセス {n} 回',
     'history.downloads': 'ダウンロード {n} 回',
@@ -610,7 +602,6 @@
     'err.exportRetry': 'エクスポートに失敗しました。再試行してください',
     'err.importFormat': 'インポートに失敗しました。ファイル形式を確認してください',
     'err.removeRetry': '削除に失敗しました。再試行してください',
-    'err.recoverRetry': '復元に失敗しました。再試行してください'
   });
 
   // ---------- العربية (RTL) ----------
@@ -733,8 +724,6 @@
     'history.export': 'تصدير السجل',
     'history.import': 'استيراد السجل',
     'history.empty': 'لا يوجد سجل إنشاء على هذا الجهاز بعد. أنشئ تطبيقًا أولاً، أو استورد سجلًا مُصدَّرًا من جهاز آخر.',
-    'history.recover': 'استعادة الإصدارات الموجودة',
-    'history.recovering': 'جارٍ الاستعادة...',
     'history.justNow': 'الآن',
     'history.visits': 'الزيارات {n}',
     'history.downloads': 'التنزيلات {n}',
@@ -796,7 +785,6 @@
     'err.exportRetry': 'فشل التصدير، يرجى إعادة المحاولة',
     'err.importFormat': 'فشل الاستيراد، يرجى التحقق من صيغة الملف',
     'err.removeRetry': 'فشلت الإزالة، يرجى إعادة المحاولة',
-    'err.recoverRetry': 'فشلت الاستعادة، يرجى إعادة المحاولة'
   });
 
   // ---------- Русский ----------
@@ -919,8 +907,6 @@
     'history.export': 'Экспорт истории',
     'history.import': 'Импорт истории',
     'history.empty': 'На этом устройстве пока нет истории сборок. Сначала создайте приложение или импортируйте запись, экспортированную с другого устройства.',
-    'history.recover': 'Восстановить существующие сборки',
-    'history.recovering': 'Восстановление...',
     'history.justNow': 'Только что',
     'history.visits': 'Посещений {n}',
     'history.downloads': 'Загрузок {n}',
@@ -982,7 +968,6 @@
     'err.exportRetry': 'Ошибка экспорта, повторите попытку',
     'err.importFormat': 'Ошибка импорта, проверьте формат файла',
     'err.removeRetry': 'Не удалось удалить, повторите попытку',
-    'err.recoverRetry': 'Не удалось восстановить, повторите попытку'
   });
 
   // ---------- Español ----------
@@ -1105,8 +1090,6 @@
     'history.export': 'Exportar historial',
     'history.import': 'Importar historial',
     'history.empty': 'Aún no hay historial de compilaciones en este dispositivo. Genera una app primero, o importa un registro exportado desde otro dispositivo.',
-    'history.recover': 'Recuperar compilaciones existentes',
-    'history.recovering': 'Recuperando...',
     'history.justNow': 'Ahora mismo',
     'history.visits': 'Visitas {n}',
     'history.downloads': 'Descargas {n}',
@@ -1168,7 +1151,6 @@
     'err.exportRetry': 'Error al exportar, inténtalo de nuevo',
     'err.importFormat': 'Error al importar, comprueba el formato del archivo',
     'err.removeRetry': 'Error al quitar, inténtalo de nuevo',
-    'err.recoverRetry': 'Error al recuperar, inténtalo de nuevo'
   });
 
   // ---------- Português ----------
@@ -1291,8 +1273,6 @@
     'history.export': 'Exportar histórico',
     'history.import': 'Importar histórico',
     'history.empty': 'Ainda não há histórico de compilações neste dispositivo. Gere um app primeiro, ou importe um registro exportado de outro dispositivo.',
-    'history.recover': 'Recuperar compilações existentes',
-    'history.recovering': 'Recuperando...',
     'history.justNow': 'Agora mesmo',
     'history.visits': 'Visitas {n}',
     'history.downloads': 'Downloads {n}',
@@ -1354,7 +1334,6 @@
     'err.exportRetry': 'Falha ao exportar, tente novamente',
     'err.importFormat': 'Falha ao importar, verifique o formato do arquivo',
     'err.removeRetry': 'Falha ao remover, tente novamente',
-    'err.recoverRetry': 'Falha ao recuperar, tente novamente'
   });
 
   // ---------- Français ----------
@@ -1477,8 +1456,6 @@
     'history.export': 'Exporter l\u2019historique',
     'history.import': 'Importer l\u2019historique',
     'history.empty': 'Aucun historique de builds sur cet appareil pour le moment. Générez d\u2019abord une application, ou importez un enregistrement exporté depuis un autre appareil.',
-    'history.recover': 'Récupérer les builds existants',
-    'history.recovering': 'Récupération...',
     'history.justNow': 'À l\u2019instant',
     'history.visits': 'Visites {n}',
     'history.downloads': 'Téléchargements {n}',
@@ -1540,7 +1517,6 @@
     'err.exportRetry': 'Échec de l\u2019exportation, veuillez réessayer',
     'err.importFormat': 'Échec de l\u2019importation, vérifiez le format du fichier',
     'err.removeRetry': 'Échec du retrait, veuillez réessayer',
-    'err.recoverRetry': 'Échec de la récupération, veuillez réessayer'
   });
 
   // ---------- Deutsch ----------
@@ -1663,8 +1639,6 @@
     'history.export': 'Verlauf exportieren',
     'history.import': 'Verlauf importieren',
     'history.empty': 'Noch kein Build-Verlauf auf diesem Gerät. Generiere zuerst eine App oder importiere einen von einem anderen Gerät exportierten Datensatz.',
-    'history.recover': 'Vorhandene Builds wiederherstellen',
-    'history.recovering': 'Wiederherstellung...',
     'history.justNow': 'Gerade eben',
     'history.visits': 'Besuche {n}',
     'history.downloads': 'Downloads {n}',
@@ -1726,6 +1700,5 @@
     'err.exportRetry': 'Export fehlgeschlagen, bitte erneut versuchen',
     'err.importFormat': 'Import fehlgeschlagen, bitte Dateiformat prüfen',
     'err.removeRetry': 'Entfernen fehlgeschlagen, bitte erneut versuchen',
-    'err.recoverRetry': 'Wiederherstellung fehlgeschlagen, bitte erneut versuchen'
   });
 })();

--- a/server/history_store.py
+++ b/server/history_store.py
@@ -593,6 +593,23 @@ class HistoryStore:
             self._set_device_app_ids_locked(device_fingerprint, filtered, _utc_now())
             return True
 
+    def remove_many_from_device(self, device_fingerprint: Optional[str], app_ids: List[str]) -> List[str]:
+        """Bulk variant of remove_from_device: one lock acquisition and one
+        write instead of N, so a large clean-up does not hammer the store."""
+        wanted = [app_id for app_id in (app_ids or []) if app_id]
+        if not device_fingerprint or not wanted:
+            return []
+        with self._lock:
+            self._flush_visits_locked()
+            previous = self._get_device_app_ids_locked(device_fingerprint)
+            previous_set = set(previous)
+            removed_set = {app_id for app_id in wanted if app_id in previous_set}
+            if not removed_set:
+                return []
+            filtered = [value for value in previous if value not in removed_set]
+            self._set_device_app_ids_locked(device_fingerprint, filtered, _utc_now())
+            return [app_id for app_id in wanted if app_id in removed_set]
+
     def list_expired_apps(self, cutoff_iso: str) -> List[dict]:
         cutoff = _parse_utc(cutoff_iso)
         if cutoff is None:

--- a/server/main.py
+++ b/server/main.py
@@ -418,6 +418,10 @@ class HistoryImportPayload(BaseModel):
     items: List[dict] = []
 
 
+class HistoryBulkDeletePayload(BaseModel):
+    app_ids: List[str] = []
+
+
 # --- API Routes ---
 @app.post("/api/analyze")
 async def analyze_url(req: AnalyzeRequest):
@@ -1161,19 +1165,6 @@ async def attach_history_item(app_id: str, request: Request):
     return {"attached": True, "app_id": app_id, "history": _history_payload(request)}
 
 
-@app.post("/api/history/recover")
-async def recover_history(request: Request):
-    device_fingerprint = _device_fingerprint(request)
-    if not device_fingerprint:
-        return {"recovered": 0, "history": _history_payload(request)}
-    recovered = 0
-    for recipe_path in sorted(APPS_DIR.glob("*/recipe.json"), key=lambda item: item.stat().st_mtime, reverse=True):
-        app_id = recipe_path.parent.name
-        history_store.attach_app(device_fingerprint, app_id)
-        recovered += 1
-    return {"recovered": recovered, "history": _history_payload(request)}
-
-
 def _decode_site_files(item: dict):
     """Decode the base64 site bundle embedded in an exported history item."""
     raw_files = (item.get("site_files") or [])
@@ -1275,6 +1266,26 @@ async def delete_history_item(app_id: str, request: Request):
     if not removed:
         raise HTTPException(404, "History item not found")
     return {"removed": True, "app_id": app_id, "history": _history_payload(request)}
+
+
+HISTORY_BULK_DELETE_MAX = 500
+
+
+@app.post("/api/history/delete-bulk")
+def delete_history_bulk(payload: HistoryBulkDeletePayload, request: Request):
+    # Sync endpoint on purpose: FastAPI runs it in the threadpool, so the
+    # blocking SQLite work stays off the event loop while a large clean-up
+    # removes every entry in one lock acquisition and one payload rebuild.
+    device_fingerprint = _device_fingerprint(request)
+    if not device_fingerprint:
+        raise HTTPException(400, "Missing device fingerprint")
+    app_ids = [app_id for app_id in payload.app_ids if app_id]
+    if not app_ids:
+        return {"removed": [], "history": _history_payload(request)}
+    if len(app_ids) > HISTORY_BULK_DELETE_MAX:
+        raise HTTPException(400, "Too many app ids")
+    removed = history_store.remove_many_from_device(device_fingerprint, app_ids)
+    return {"removed": removed, "history": _history_payload(request)}
 
 
 @app.on_event("shutdown")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -101,3 +101,75 @@ class EntryCacheHeaderTests(unittest.TestCase):
         resp = self.client.get("/css/style.css")
         self.assertEqual(resp.status_code, 200)
         self.assertIn("max-age=86400", resp.headers.get("cache-control", ""))
+
+
+class HistoryBulkDeleteTests(unittest.TestCase):
+    """POST /api/history/delete-bulk — one request replaces the per-id DELETE
+    fan-out that froze the server (issue #59), and the old /api/history/recover
+    endpoint (which attached every app on the server to the caller) is gone."""
+
+    FP = "test-device-fp"
+
+    def setUp(self):
+        self.client = TestClient(main.app)
+        self._tmp = tempfile.TemporaryDirectory()
+        self.apps_dir = Path(self._tmp.name)
+        self.original_apps_dir = main.APPS_DIR
+        self.original_store = main.history_store
+        main.APPS_DIR = self.apps_dir
+        main.history_store = __import__("server.history_store", fromlist=["HistoryStore"]).HistoryStore(
+            self.apps_dir / "_history.json"
+        )
+
+    def tearDown(self):
+        main.APPS_DIR = self.original_apps_dir
+        main.history_store = self.original_store
+        self._tmp.cleanup()
+
+    def _record(self, app_id):
+        (self.apps_dir / app_id).mkdir(parents=True, exist_ok=True)
+        main.history_store.record_build(self.FP, {"id": app_id, "name": app_id, "url": f"https://{app_id}.test"}, f"/a/{app_id}", None)
+
+    def _cookies(self):
+        return {"webtoapp_device_fingerprint": self.FP}
+
+    def test_bulk_delete_removes_only_requested_ids(self):
+        for app_id in ("a1", "b2", "c3"):
+            self._record(app_id)
+        resp = self.client.post(
+            "/api/history/delete-bulk",
+            json={"app_ids": ["a1", "c3", "missing"]},
+            cookies=self._cookies(),
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["removed"], ["a1", "c3"])
+        remaining = [item["app_id"] for item in resp.json()["history"]["items"]]
+        self.assertEqual(remaining, ["b2"])
+
+    def test_bulk_delete_requires_device_fingerprint(self):
+        resp = self.client.post("/api/history/delete-bulk", json={"app_ids": ["a1"]})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_bulk_delete_rejects_oversized_payload(self):
+        app_ids = [f"app{i}" for i in range(main.HISTORY_BULK_DELETE_MAX + 1)]
+        resp = self.client.post(
+            "/api/history/delete-bulk",
+            json={"app_ids": app_ids},
+            cookies=self._cookies(),
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_bulk_delete_empty_list_is_a_noop(self):
+        resp = self.client.post(
+            "/api/history/delete-bulk",
+            json={"app_ids": []},
+            cookies=self._cookies(),
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["removed"], [])
+
+    def test_recover_endpoint_is_removed(self):
+        # 405 (matches the DELETE /{app_id} route as "recover") proves no POST
+        # recover handler exists anymore.
+        resp = self.client.post("/api/history/recover", cookies=self._cookies())
+        self.assertIn(resp.status_code, (404, 405))


### PR DESCRIPTION
Fixes #59

## Summary

- **Bulk delete performance**: selection-mode delete fired N parallel `DELETE /api/history/{id}` calls; each blocked the event loop and rebuilt the full history payload, so N deletes cost N × O(all history) work and froze the 4C/4G box. Replaced with a single `POST /api/history/delete-bulk` taking `{app_ids}` — one lock acquisition, one transaction, one payload rebuild, capped at 500 ids, run as a sync `def` endpoint so the blocking SQLite work executes in the threadpool.
- **Cross-user data leak**: `POST /api/history/recover` attached EVERY app on the server to the caller's device fingerprint with no scoping, exposing other users' complete histories. Removed the endpoint, its UI button, handler, CSS and i18n keys — without auth there is no safe fingerprint recovery; export/import remains the supported path.

## Test plan

- New `HistoryBulkDeleteTests`: removes exactly the requested ids (unknown ids ignored, history reflects removals), 400 without fingerprint, 400 on >500 ids, empty list is a no-op, recover POST returns 404/405
- Full suite: 252 passed (247 + 5 new)
- `node --check` on app.v5.js / i18n.strings.js